### PR TITLE
Implement couple local like and YT like functionality

### DIFF
--- a/app/src/main/java/com/maxrave/simpmusic/data/dataStore/DataStoreManager.kt
+++ b/app/src/main/java/com/maxrave/simpmusic/data/dataStore/DataStoreManager.kt
@@ -265,6 +265,25 @@ class DataStoreManager
             }
         }
 
+        val coupleLocalAndYouTubeLike =
+            settingsDataStore.data.map { preferences ->
+                preferences[COUPLE_LOCAL_AND_YOUTUBE_LIKE] ?: FALSE
+            }
+
+        suspend fun setCoupleLocalAndYouTubeLike(coupleLocalAndYouTubeLike: Boolean) {
+            withContext(Dispatchers.IO) {
+                if (coupleLocalAndYouTubeLike) {
+                    settingsDataStore.edit { settings ->
+                        settings[COUPLE_LOCAL_AND_YOUTUBE_LIKE] = TRUE
+                    }
+                } else {
+                    settingsDataStore.edit { settings ->
+                        settings[COUPLE_LOCAL_AND_YOUTUBE_LIKE] = FALSE
+                    }
+                }
+            }
+        }
+
         val sponsorBlockEnabled =
             settingsDataStore.data.map { preferences ->
                 preferences[SPONSOR_BLOCK_ENABLED] ?: FALSE
@@ -560,6 +579,7 @@ class DataStoreManager
             val SHUFFLE_KEY = stringPreferencesKey("shuffle_key")
             val REPEAT_KEY = stringPreferencesKey("repeat_key")
             val SEND_BACK_TO_GOOGLE = stringPreferencesKey("send_back_to_google")
+            val COUPLE_LOCAL_AND_YOUTUBE_LIKE = stringPreferencesKey("couple_local_and_youtube_like")
             val FROM_SAVED_PLAYLIST = stringPreferencesKey("from_saved_playlist")
             val MUSIXMATCH_LOGGED_IN = stringPreferencesKey("musixmatch_logged_in")
             val YOUTUBE = "youtube"

--- a/app/src/main/java/com/maxrave/simpmusic/ui/MainActivity.kt
+++ b/app/src/main/java/com/maxrave/simpmusic/ui/MainActivity.kt
@@ -732,7 +732,7 @@ class MainActivity : AppCompatActivity() {
         binding.card.animation = AnimationUtils.loadAnimation(this, R.anim.bottom_to_top)
         binding.cbFavorite.setOnClickListener {
             viewModel.nowPlayingMediaItem.value?.let { nowPlayingSong ->
-                viewModel.updateLikeStatus(
+                viewModel.updateLike(
                     nowPlayingSong.mediaId,
                     !runBlocking { viewModel.liked.first() },
                 )

--- a/app/src/main/java/com/maxrave/simpmusic/ui/fragment/home/SettingsFragment.kt
+++ b/app/src/main/java/com/maxrave/simpmusic/ui/fragment/home/SettingsFragment.kt
@@ -117,6 +117,7 @@ class SettingsFragment : Fragment() {
         viewModel.getSkipSilent()
         viewModel.getSavedPlaybackState()
         viewModel.getSendBackToGoogle()
+        viewModel.getCoupleLocalAndYouTubeLike()
         viewModel.getSaveRecentSongAndQueue()
         viewModel.getLastCheckForUpdate()
         viewModel.getSponsorBlockEnabled()
@@ -408,6 +409,11 @@ class SettingsFragment : Fragment() {
                         }
                     }
                 }
+                val job27 = launch {
+                    viewModel.coupleLocalAndYouTubeLike.collect {
+                        binding.swCoupleLocalAndYouTubeLike.isChecked = it == DataStoreManager.TRUE
+                    }
+                }
                 job1.join()
                 job2.join()
                 job3.join()
@@ -434,6 +440,7 @@ class SettingsFragment : Fragment() {
                 job24.join()
                 job25.join()
                 job26.join()
+                job27.join()
             }
         }
         binding.sliderHomeLimit.addOnSliderTouchListener(object : Slider.OnSliderTouchListener {
@@ -914,6 +921,9 @@ class SettingsFragment : Fragment() {
             } else {
                 viewModel.setSendBackToGoogle(false)
             }
+        }
+        binding.swCoupleLocalAndYouTubeLike.setOnCheckedChangeListener { _, checked ->
+            viewModel.setCoupleLocalAndYouTubeLike(checked)
         }
         binding.swUseMusixmatchTranslation.setOnCheckedChangeListener { _, checked ->
             if (checked) {

--- a/app/src/main/java/com/maxrave/simpmusic/ui/fragment/player/FullscreenFragment.kt
+++ b/app/src/main/java/com/maxrave/simpmusic/ui/fragment/player/FullscreenFragment.kt
@@ -404,11 +404,11 @@ class FullscreenFragment : Fragment() {
                                     if (cbFavorite.isChecked) {
                                         cbFavorite.isChecked = false
                                         tvFavorite.text = getString(R.string.like)
-                                        viewModel.updateLikeStatus(song.videoId, false)
+                                        viewModel.unlike(song.videoId)
                                     } else {
                                         cbFavorite.isChecked = true
                                         tvFavorite.text = getString(R.string.liked)
-                                        viewModel.updateLikeStatus(song.videoId, true)
+                                        viewModel.like(song.videoId)
                                     }
                                 }
                                 btRadio.setOnClickListener {

--- a/app/src/main/java/com/maxrave/simpmusic/ui/fragment/player/NowPlayingFragment.kt
+++ b/app/src/main/java/com/maxrave/simpmusic/ui/fragment/player/NowPlayingFragment.kt
@@ -1395,7 +1395,7 @@ class NowPlayingFragment : Fragment() {
         }
         binding.cbFavorite.setOnClickListener {
             viewModel.nowPlayingMediaItem.value?.let { nowPlayingSong ->
-                viewModel.updateLikeStatus(
+                viewModel.updateLike(
                     nowPlayingSong.mediaId,
                     !runBlocking { viewModel.liked.first() },
                 )
@@ -1537,11 +1537,11 @@ class NowPlayingFragment : Fragment() {
                                     if (cbFavorite.isChecked) {
                                         cbFavorite.isChecked = false
                                         tvFavorite.text = getString(R.string.like)
-                                        viewModel.updateLikeStatus(song.videoId, false)
+                                        viewModel.updateLike(song.videoId, false)
                                     } else {
                                         cbFavorite.isChecked = true
                                         tvFavorite.text = getString(R.string.liked)
-                                        viewModel.updateLikeStatus(song.videoId, true)
+                                        viewModel.updateLike(song.videoId, true)
                                     }
                                 }
                                 btPlayNext.visibility = View.GONE

--- a/app/src/main/java/com/maxrave/simpmusic/viewModel/SettingsViewModel.kt
+++ b/app/src/main/java/com/maxrave/simpmusic/viewModel/SettingsViewModel.kt
@@ -88,6 +88,8 @@ class SettingsViewModel @Inject constructor(
     val sponsorBlockCategories: StateFlow<ArrayList<String>?> = _sponsorBlockCategories
     private var _sendBackToGoogle: MutableStateFlow<String?> = MutableStateFlow(null)
     val sendBackToGoogle: StateFlow<String?> = _sendBackToGoogle
+    private var _coupleLocalAndYouTubeLike: MutableStateFlow<String?> = MutableStateFlow(null)
+    val coupleLocalAndYouTubeLike: StateFlow<String?> = _coupleLocalAndYouTubeLike
     private var _mainLyricsProvider: MutableStateFlow<String?> = MutableStateFlow(null)
     val mainLyricsProvider: StateFlow<String?> = _mainLyricsProvider
     private var _musixmatchLoggedIn: MutableStateFlow<String?> = MutableStateFlow(null)
@@ -466,7 +468,6 @@ class SettingsViewModel @Inject constructor(
     }
     fun getSendBackToGoogle() {
         viewModelScope.launch {
-
                 dataStoreManager.sendBackToGoogle.collect { sendBackToGoogle ->
                     _sendBackToGoogle.emit(sendBackToGoogle)
             }
@@ -476,6 +477,19 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
                 dataStoreManager.setSendBackToGoogle(sendBackToGoogle)
                 getSendBackToGoogle()
+        }
+    }
+    fun getCoupleLocalAndYouTubeLike() {
+        viewModelScope.launch {
+                dataStoreManager.coupleLocalAndYouTubeLike.collect { coupleLocalAndYouTubeLike ->
+                    _coupleLocalAndYouTubeLike.emit(coupleLocalAndYouTubeLike)
+            }
+        }
+    }
+    fun setCoupleLocalAndYouTubeLike(coupleLocalAndYouTubeLike: Boolean) {
+        viewModelScope.launch {
+                dataStoreManager.setCoupleLocalAndYouTubeLike(coupleLocalAndYouTubeLike)
+                getCoupleLocalAndYouTubeLike()
         }
     }
     fun getSkipSilent() {

--- a/app/src/main/java/com/maxrave/simpmusic/viewModel/SharedViewModel.kt
+++ b/app/src/main/java/com/maxrave/simpmusic/viewModel/SharedViewModel.kt
@@ -1188,9 +1188,9 @@ class SharedViewModel
         fun like(videoId: String) {
             updateLikeStatus(videoId, true)
             viewModelScope.launch {
-                dataStoreManager.coupleLocalAndYouTubeLike.collect {
+                dataStoreManager.coupleLocalAndYouTubeLike.first().let {
                     if (it == DataStoreManager.TRUE) {
-                        logInToYouTube().collect {
+                        logInToYouTube().first().let {
                             if (it == DataStoreManager.TRUE) {
                                 val result = listYouTubeLiked.first()?.contains(videoId)
                                 if (result == null || result == false) {
@@ -1206,9 +1206,9 @@ class SharedViewModel
         fun unlike(videoId: String) {
             updateLikeStatus(videoId, false)
             viewModelScope.launch {
-                dataStoreManager.coupleLocalAndYouTubeLike.collect {
+                dataStoreManager.coupleLocalAndYouTubeLike.first().let {
                     if (it == DataStoreManager.TRUE) {
-                        logInToYouTube().collect {
+                        logInToYouTube().first().let {
                             if (it == DataStoreManager.TRUE) {
                                 if ((listYouTubeLiked.first()?.contains(videoId) == true)) {
                                     addToYouTubeLiked()

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -316,6 +316,49 @@
 
                     </com.google.android.material.switchmaterial.SwitchMaterial>
                 </RelativeLayout>
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <LinearLayout
+                        android:layout_alignParentStart="true"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:layout_marginVertical="5sp"
+                        android:layout_marginStart="15sp"
+                        android:id="@+id/btCoupleLocalAndYouTubeLike"
+                        android:focusable="true"
+                        android:clickable="true"
+                        android:foreground="?android:attr/selectableItemBackground"
+                        android:layout_toStartOf="@+id/swCoupleLocalAndYouTubeLike">
+                        <TextView
+                            android:textSize = "16sp"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textColor="@android:color/white"
+                            android:text = "@string/couple_local_like_and_youtube_like">
+
+                        </TextView>
+                        <TextView
+                            android:id="@+id/tvCoupleLocalAndYouTubeLike"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textSize="11sp"
+                            android:text="@string/using_the_local_like_button_the_youtube_like_playlist_will_be_maintained_as_well_only_if_logged_in">
+
+                        </TextView>
+
+                    </LinearLayout>
+                    <com.google.android.material.switchmaterial.SwitchMaterial
+                        android:id="@+id/swCoupleLocalAndYouTubeLike"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentEnd="true"
+                        android:layout_centerVertical="true">
+
+                    </com.google.android.material.switchmaterial.SwitchMaterial>
+                </RelativeLayout>
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -217,6 +217,8 @@
     <string name="welcome_back">مرحبًا بك مجددًا</string>
     <string name="upload_your_listening_history_to_youtube_music_server_it_will_make_yt_music_recommendation_system_better_working_only_if_logged_in">تحميل سجل الاستماع الخاص بك إلى خادم YouTube Music، سوف يجعل نظام توصية YT Music أفضل. يعمل فقط في حالة تسجيل الدخول</string>
     <string name="send_back_listening_data_to_google">إرسال بيانات الاستماع مرة أخرى إلى جوجل</string>
+    <string name="couple_local_like_and_youtube_like">TODO</string>
+    <string name="using_the_local_like_button_the_youtube_like_playlist_will_be_maintained_as_well_only_if_logged_in">TODO</string>
     <string name="videos_inArtist">مقاطع الفيديو</string>
     <string name="your_youtube_playlists">قوائم تشغيل YouTube الخاصة بك</string>
     <string name="no_YouTube_playlists">لا توجد قوائم تشغيل YouTube</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -217,6 +217,8 @@
     <string name="welcome_back">Willkommen zurück,</string>
     <string name="upload_your_listening_history_to_youtube_music_server_it_will_make_yt_music_recommendation_system_better_working_only_if_logged_in">Lade deinen Hörverlauf auf die YouTube Music-Server hoch. Dadurch wird das YT Music-Empfehlungssystem verbessert. Funktioniert nur, wenn du angemeldet bist</string>
     <string name="send_back_listening_data_to_google">Hördaten an Google zurücksenden</string>
+    <string name="couple_local_like_and_youtube_like">Verknüpfe lokalen Like und YT Like</string>
+    <string name="using_the_local_like_button_the_youtube_like_playlist_will_be_maintained_as_well_only_if_logged_in">Wenn der lokale Like Button verwendet wird, wird auch automatisch die YT Like Playlist gepflegt. Funktioniert nur, wenn du angemeldet bist</string>
     <string name="videos_inArtist">Videos</string>
     <string name="your_youtube_playlists">Deine YouTube-Playlists</string>
     <string name="no_YouTube_playlists">Keine YouTube-Playlists</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -217,6 +217,8 @@
     <string name="welcome_back">¡Bienvenido de vuelta</string>
     <string name="upload_your_listening_history_to_youtube_music_server_it_will_make_yt_music_recommendation_system_better_working_only_if_logged_in">Sube tu historial de escucha al servidor de música de YouTube, mejorará el sistema de recomendaciones de YT Music. Solo funciona si inicias sesión</string>
     <string name="send_back_listening_data_to_google">Enviar datos de vuelta de escucha a Google</string>
+    <string name="couple_local_like_and_youtube_like">TODO</string>
+    <string name="using_the_local_like_button_the_youtube_like_playlist_will_be_maintained_as_well_only_if_logged_in">TODO</string>
     <string name="videos_inArtist">Vídeos</string>
     <string name="your_youtube_playlists">Tus listas de reproducción de YouTube</string>
     <string name="no_YouTube_playlists">No hay listas de YouTube</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -217,6 +217,8 @@
     <string name="welcome_back">Tervetuloa takaisin,</string>
     <string name="upload_your_listening_history_to_youtube_music_server_it_will_make_yt_music_recommendation_system_better_working_only_if_logged_in">Lataamalla kuunteluhistoria YouTube Music -palvelimelle parannetaan YT Music -suosituksia. Toimii vain sisäänkirjautuneena</string>
     <string name="send_back_listening_data_to_google">Lähetä kuuntelutiedot Googlelle</string>
+    <string name="couple_local_like_and_youtube_like">TODO</string>
+    <string name="using_the_local_like_button_the_youtube_like_playlist_will_be_maintained_as_well_only_if_logged_in">TODO</string>
     <string name="videos_inArtist">Videot</string>
     <string name="your_youtube_playlists">YouTube-soittolistasi</string>
     <string name="no_YouTube_playlists">Ei YouTube-soittolistoja</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -217,6 +217,8 @@
     <string name="welcome_back">Bienvenue,</string>
     <string name="upload_your_listening_history_to_youtube_music_server_it_will_make_yt_music_recommendation_system_better_working_only_if_logged_in">Téléchargez votre historique d\'écoute sur le serveur YouTube Music, cela améliorera le système de recommandation de YT Music. Fonctionne uniquement si vous êtes connecté</string>
     <string name="send_back_listening_data_to_google">Renvoyer les données d\'écoute à Google</string>
+    <string name="couple_local_like_and_youtube_like">TODO</string>
+    <string name="using_the_local_like_button_the_youtube_like_playlist_will_be_maintained_as_well_only_if_logged_in">TODO</string>
     <string name="videos_inArtist">Vidéos</string>
     <string name="your_youtube_playlists">Vos playlists YouTube</string>
     <string name="no_YouTube_playlists">Aucune playlists YouTube</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -217,6 +217,8 @@
     <string name="welcome_back">Selamat datang kembali,</string>
     <string name="upload_your_listening_history_to_youtube_music_server_it_will_make_yt_music_recommendation_system_better_working_only_if_logged_in">Unggah riwayat yang didengarkan Anda ke server YouTube Music, ini akan membuat sistem rekomendasi YT Music menjadi lebih baik. Hanya berfungsi jika masuk</string>
     <string name="send_back_listening_data_to_google">Kirim kembali data pendengaran ke Google</string>
+    <string name="couple_local_like_and_youtube_like">TODO</string>
+    <string name="using_the_local_like_button_the_youtube_like_playlist_will_be_maintained_as_well_only_if_logged_in">TODO</string>
     <string name="videos_inArtist">Video</string>
     <string name="your_youtube_playlists">Daftar Playlist Anda</string>
     <string name="no_YouTube_playlists">Tidak ada Playlist YouTube</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -217,6 +217,8 @@
     <string name="welcome_back">Bentornato,</string>
     <string name="upload_your_listening_history_to_youtube_music_server_it_will_make_yt_music_recommendation_system_better_working_only_if_logged_in">Carica la tua cronologia di ascolto sul server YouTube Music, migliorerà il sistema di consigli di YT Music. Funzionante solo se loggato</string>
     <string name="send_back_listening_data_to_google">Invia i dati di ascolto a Google</string>
+    <string name="couple_local_like_and_youtube_like">TODO</string>
+    <string name="using_the_local_like_button_the_youtube_like_playlist_will_be_maintained_as_well_only_if_logged_in">TODO</string>
     <string name="videos_inArtist">Video</string>
     <string name="your_youtube_playlists">Le tue playlist di YouTube</string>
     <string name="no_YouTube_playlists">Nessuna playlist di YouTube</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -217,6 +217,8 @@
     <string name="welcome_back">お帰りなさい ！</string>
     <string name="upload_your_listening_history_to_youtube_music_server_it_will_make_yt_music_recommendation_system_better_working_only_if_logged_in">YouTubeミュージックサーバーにリスニング履歴をアップロードすると、YTミュージックのおすすめシステムがより良くなります。ログインしている場合にのみ動作します</string>
     <string name="send_back_listening_data_to_google">Google にリスニングデータを送信する</string>
+    <string name="couple_local_like_and_youtube_like">TODO</string>
+    <string name="using_the_local_like_button_the_youtube_like_playlist_will_be_maintained_as_well_only_if_logged_in">TODO</string>
     <string name="videos_inArtist">動画</string>
     <string name="your_youtube_playlists">あなたのYouTubeプレイリスト</string>
     <string name="no_YouTube_playlists">YouTubeのプレイリストがありません</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -217,6 +217,8 @@
     <string name="welcome_back">Witamy ponownie</string>
     <string name="upload_your_listening_history_to_youtube_music_server_it_will_make_yt_music_recommendation_system_better_working_only_if_logged_in">Prześlij historię słuchania na serwer YouTube Music, poprawi to system rekomendacji muzyki YT. Działa tylko wtedy, gdy zalogowany</string>
     <string name="send_back_listening_data_to_google">Wyślij z powrotem dane słuchania do Google</string>
+    <string name="couple_local_like_and_youtube_like">TODO</string>
+    <string name="using_the_local_like_button_the_youtube_like_playlist_will_be_maintained_as_well_only_if_logged_in">TODO</string>
     <string name="videos_inArtist">Filmy</string>
     <string name="your_youtube_playlists">Twoje playlisty YouTube</string>
     <string name="no_YouTube_playlists">Brak playlist YouTube</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -217,6 +217,8 @@
     <string name="welcome_back">Bem-vindo de volta,</string>
     <string name="upload_your_listening_history_to_youtube_music_server_it_will_make_yt_music_recommendation_system_better_working_only_if_logged_in">Envie seu histórico de música para o servidor do Youtube Music. Assim, o sistema de recomendações do YT Music ficará melhor. Funcional apenas se estiver logado</string>
     <string name="send_back_listening_data_to_google">Enviar dados de reprodução para o Google</string>
+    <string name="couple_local_like_and_youtube_like">TODO</string>
+    <string name="using_the_local_like_button_the_youtube_like_playlist_will_be_maintained_as_well_only_if_logged_in">TODO</string>
     <string name="videos_inArtist">Vídeos</string>
     <string name="your_youtube_playlists">Suas Playlists do YouTube</string>
     <string name="no_YouTube_playlists">Nenhuma playlist do YouTube</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -217,6 +217,8 @@
     <string name="welcome_back">Добро пожаловать,</string>
     <string name="upload_your_listening_history_to_youtube_music_server_it_will_make_yt_music_recommendation_system_better_working_only_if_logged_in">Загрузите свою историю прослушивания на сервер YouTube Music, это улучшит систему рекомендаций YT Music. Работает только если авторизован</string>
     <string name="send_back_listening_data_to_google">Отправьте данные о прослушивании обратно в Google</string>
+    <string name="couple_local_like_and_youtube_like">TODO</string>
+    <string name="using_the_local_like_button_the_youtube_like_playlist_will_be_maintained_as_well_only_if_logged_in">TODO</string>
     <string name="videos_inArtist">Видео</string>
     <string name="your_youtube_playlists">Ваши плейлисты YouTube</string>
     <string name="no_YouTube_playlists">Нет плейлистов YouTube</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -217,6 +217,8 @@
     <string name="welcome_back">Tekrar hoş geldiniz</string>
     <string name="upload_your_listening_history_to_youtube_music_server_it_will_make_yt_music_recommendation_system_better_working_only_if_logged_in">Dinleme geçmişinizi YouTube Müzik sunucusuna yükleyin, YT Müzik öneri sistemini daha iyi hale getirecektir. Sadece giriş yapıldığında çalışır</string>
     <string name="send_back_listening_data_to_google">Dinleme verilerini Google\'a geri gönder</string>
+    <string name="couple_local_like_and_youtube_like">TODO</string>
+    <string name="using_the_local_like_button_the_youtube_like_playlist_will_be_maintained_as_well_only_if_logged_in">TODO</string>
     <string name="videos_inArtist">Videolar</string>
     <string name="your_youtube_playlists">YouTube Oynatma Listeleriniz</string>
     <string name="no_YouTube_playlists">YouTube Oynatma Listesi yok</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -217,6 +217,8 @@
     <string name="welcome_back">Chào mừng trở lại,</string>
     <string name="upload_your_listening_history_to_youtube_music_server_it_will_make_yt_music_recommendation_system_better_working_only_if_logged_in">Tải lên dữ liệu lịch sử phát lại tới YouTube Music, giúp hệ thống gợi ý hoạt động tốt hơn. Hoạt động khi đã đăng nhập</string>
     <string name="send_back_listening_data_to_google">Gửi dữ liệu nghe nhạc về Google</string>
+    <string name="couple_local_like_and_youtube_like">TODO</string>
+    <string name="using_the_local_like_button_the_youtube_like_playlist_will_be_maintained_as_well_only_if_logged_in">TODO</string>
     <string name="videos_inArtist">Video</string>
     <string name="your_youtube_playlists">Danh sách phát YouTube của bạn</string>
     <string name="no_YouTube_playlists">Không có danh sách phát YouTube nào</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -217,6 +217,8 @@
     <string name="welcome_back">欢迎回来</string>
     <string name="upload_your_listening_history_to_youtube_music_server_it_will_make_yt_music_recommendation_system_better_working_only_if_logged_in">将您的听歌历史上传到 YouTube Music 服务器，它将使 YT Music 推荐系统更好。只在登录后才工作</string>
     <string name="send_back_listening_data_to_google">发送回听数据到 Google</string>
+    <string name="couple_local_like_and_youtube_like">TODO</string>
+    <string name="using_the_local_like_button_the_youtube_like_playlist_will_be_maintained_as_well_only_if_logged_in">TODO</string>
     <string name="videos_inArtist">视频</string>
     <string name="your_youtube_playlists">您的 YouTube 歌单</string>
     <string name="no_YouTube_playlists">没有 YouTube 歌单</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -218,6 +218,8 @@
     <string name="welcome_back">Welcome back,</string>
     <string name="upload_your_listening_history_to_youtube_music_server_it_will_make_yt_music_recommendation_system_better_working_only_if_logged_in">Upload your listening history to YouTube Music server, it will make YT Music recommendation system better. Working only if logged in</string>
     <string name="send_back_listening_data_to_google">Send back listening data to Google</string>
+    <string name="couple_local_like_and_youtube_like">Couple local like and YT like</string>
+    <string name="using_the_local_like_button_the_youtube_like_playlist_will_be_maintained_as_well_only_if_logged_in">Using the local like button, the YT like playlist will be maintained as well. Working only if logged in</string>
     <string name="videos_inArtist">Videos</string>
     <string name="your_youtube_playlists">Your YouTube Playlists</string>
     <string name="no_YouTube_playlists">No YouTube Playlists</string>


### PR DESCRIPTION
Hello,
first of all thanks for the app, it is really nice.

When I was using the app, I found it very tedious that I had to like a song separately for YouTube.
So I added a opt in functionality to do both using the Heart button.

There are a few open tasks that need to be done before this could be merged, where I need your assistance:
1. What do I do about the translations for all languages besides the one I am capable of speaking?
2. I noticed that the updateLikeStatus functionality is used all over the place. The place where I implemented the functionality is the SharedViewModel but this is not used by all views. I was looking for some kind of "UseCase"-Service or somewhere else to put it, any idea what could be a good place?
3. Also I am unsure of when a likeStatus counts towards an album/artist or song, as I think the YT Like button only works for the latter.

Cheers!