### PR TITLE
fix: Prevent Toast from showing in background and add player error code

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -238,6 +238,7 @@ dependencies {
     implementation(project(mapOf("path" to ":kotlinYtmusicScraper")))
     implementation(project(mapOf("path" to ":spotify")))
     implementation(project(mapOf("path" to ":aiService")))
+    implementation(project(mapOf("path" to ":sharedutils")))
 
     implementation(libs.lifecycle.livedata.ktx)
     implementation(libs.lifecycle.viewmodel.ktx)

--- a/app/src/main/java/com/maxrave/simpmusic/service/SimpleMediaServiceHandler.kt
+++ b/app/src/main/java/com/maxrave/simpmusic/service/SimpleMediaServiceHandler.kt
@@ -886,7 +886,7 @@ class SimpleMediaServiceHandler(
                             Toast.LENGTH_LONG,
                         ).show()
                 } else {
-                    Log.e("Player Error", "App is not in foreground, skipping toast")
+                    Log.w("Player Error", "App is not in foreground, skipping toast")
                 }
                 player.pause()
             }
@@ -904,7 +904,7 @@ class SimpleMediaServiceHandler(
                             Toast.LENGTH_LONG,
                         ).show()
                 } else {
-                    Log.e("Player Error", "App is not in foreground, skipping toast")
+                    Log.w("Player Error", "App is not in foreground, skipping toast")
                 }
                 player.pause()
             }

--- a/app/src/main/java/com/maxrave/simpmusic/service/SimpleMediaServiceHandler.kt
+++ b/app/src/main/java/com/maxrave/simpmusic/service/SimpleMediaServiceHandler.kt
@@ -29,6 +29,7 @@ import coil3.imageLoader
 import coil3.request.ImageRequest
 import coil3.request.placeholder
 import coil3.toBitmap
+import com.liskovsoft.sharedutils.helpers.Helpers
 import com.maxrave.kotlinytmusicscraper.models.WatchEndpoint
 import com.maxrave.kotlinytmusicscraper.models.sponsorblock.SkipSegments
 import com.maxrave.simpmusic.R
@@ -873,24 +874,32 @@ class SimpleMediaServiceHandler(
     override fun onPlayerError(error: PlaybackException) {
         when (error.errorCode) {
             PlaybackException.ERROR_CODE_TIMEOUT -> {
-                Log.e("Player Error", "onPlayerError: ${error.message}")
-                Toast
-                    .makeText(
-                        context,
-                        context.getString(R.string.time_out_check_internet_connection_or_change_piped_instance_in_settings),
-                        Toast.LENGTH_LONG,
-                    ).show()
+                Log.e("Player Error", "onPlayerError (${error.errorCode}): ${error.message}")
+                if (Helpers.isAppInForeground()) {
+                    Toast
+                        .makeText(
+                            context,
+                            context.getString(R.string.time_out_check_internet_connection_or_change_piped_instance_in_settings),
+                            Toast.LENGTH_LONG,
+                        ).show()
+                } else {
+                    Log.e("Player Error", "App is not in foreground, skipping toast")
+                }
                 player.pause()
             }
 
             else -> {
-                Log.e("Player Error", "onPlayerError: ${error.message}")
-                Toast
-                    .makeText(
-                        context,
-                        context.getString(R.string.time_out_check_internet_connection_or_change_piped_instance_in_settings),
-                        Toast.LENGTH_LONG,
-                    ).show()
+                Log.e("Player Error", "onPlayerError (${error.errorCode}): ${error.message}")
+                if (Helpers.isAppInForeground()) {
+                    Toast
+                        .makeText(
+                            context,
+                            context.getString(R.string.time_out_check_internet_connection_or_change_piped_instance_in_settings),
+                            Toast.LENGTH_LONG,
+                        ).show()
+                } else {
+                    Log.e("Player Error", "App is not in foreground, skipping toast")
+                }
                 player.pause()
             }
         }

--- a/app/src/main/java/com/maxrave/simpmusic/service/SimpleMediaServiceHandler.kt
+++ b/app/src/main/java/com/maxrave/simpmusic/service/SimpleMediaServiceHandler.kt
@@ -879,7 +879,10 @@ class SimpleMediaServiceHandler(
                     Toast
                         .makeText(
                             context,
-                            context.getString(R.string.time_out_check_internet_connection_or_change_piped_instance_in_settings),
+                            context.getString(
+                                R.string.time_out_check_internet_connection_or_change_piped_instance_in_settings,
+                                error.errorCode,
+                            ),
                             Toast.LENGTH_LONG,
                         ).show()
                 } else {
@@ -894,7 +897,10 @@ class SimpleMediaServiceHandler(
                     Toast
                         .makeText(
                             context,
-                            context.getString(R.string.time_out_check_internet_connection_or_change_piped_instance_in_settings),
+                            context.getString(
+                                R.string.time_out_check_internet_connection_or_change_piped_instance_in_settings,
+                                error.errorCode,
+                            ),
                             Toast.LENGTH_LONG,
                         ).show()
                 } else {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">حفظ الوضع العشوائي و التكرار</string>
     <string name="skip_silent">تخطي الوضع الصامت</string>
     <string name="skip_no_music_part">تخطي لا جزء موسيقى</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">انتهت المهلة، تحقق من الاتصال بالإنترنت</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">(%1$d) انتهت المهلة، تحقق من الاتصال بالإنترنت</string>
     <string name="save_last_played">حفظ آخر تشغيل</string>
     <string name="save_last_played_track_and_queue">حفظ آخر مسار وقائمة الانتظار تم تشغيله</string>
     <string name="update_available">تحديث جديد متوفر</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">Qarışdır və təkrarla rejimin saxla</string>
     <string name="skip_silent">Səssizliyi Ötür</string>
     <string name="skip_no_music_part">Musiqisiz hissəni ötür</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Vaxt bitdi, internet bağlantısın yoxla</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Vaxt bitdi, internet bağlantısın yoxla (%1$d)</string>
     <string name="save_last_played">Son Oynadılanı Saxla</string>
     <string name="save_last_played_track_and_queue">Son səslənən axını və növbəni saxla</string>
     <string name="update_available">Yeni quraşdırma mövcuddur</string>

--- a/app/src/main/res/values-b+zh+Hant+TW/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant+TW/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">保存随机和重复模式</string>
     <string name="skip_silent">跳过静音</string>
     <string name="skip_no_music_part">跳过没有音乐部分</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">超时，检查网络连接</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">超时，检查网络连接 (%1$d)</string>
     <string name="save_last_played">保存上次播放</string>
     <string name="save_last_played_track_and_queue">保存上次播放的曲目和队列</string>
     <string name="update_available">有可用的更新</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">Запази режим разбъркване и повторение</string>
     <string name="skip_silent">Прескочи тишината</string>
     <string name="skip_no_music_part">Прескочи частта без музика</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Времето изтече. Проверете интернет връзката си</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Времето изтече. Проверете интернет връзката си (%1$d)</string>
     <string name="save_last_played">Запази последното възпроизвеждане</string>
     <string name="save_last_played_track_and_queue">Запази последната изпълнена песен и опашката</string>
     <string name="update_available">Налична е нова актуализация</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">Desa el mode de reproducció i repetició</string>
     <string name="skip_silent">Saltar en silenci</string>
     <string name="skip_no_music_part">No salteu cap part de música</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Temps mort, comproveu la connexió a Internet</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Temps mort, comproveu la connexió a Internet (%1$d)</string>
     <string name="save_last_played">Desa l\'última reproducció</string>
     <string name="save_last_played_track_and_queue">Desa la darrera pista reproduïda i la cua</string>
     <string name="update_available">Nova actualització disponible</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">Zufalls- und Wiederholungswiedergabe speichern</string>
     <string name="skip_silent">Stille überspringen</string>
     <string name="skip_no_music_part">Teile ohne Musik überspringen</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Keine Antwort vom Server, prüfe deine Internetverbindung</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Keine Antwort vom Server, prüfe deine Internetverbindung (%1$d)</string>
     <string name="save_last_played">Zuletzt gespielt speichern</string>
     <string name="save_last_played_track_and_queue">Zuletzt gespielten Song und Wiedergabeliste speichern</string>
     <string name="update_available">Neues Update verfügbar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">Guardar modo aleatorio y repetición</string>
     <string name="skip_silent">Omitir silencio</string>
     <string name="skip_no_music_part">Saltar segmentos sin música</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Tiempo agotado, compruebe la conexión a internet</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Tiempo agotado, compruebe la conexión a internet (%1$d)</string>
     <string name="save_last_played">Guardar Última Reproducción</string>
     <string name="save_last_played_track_and_queue">Guardar última pista reproducida y cola</string>
     <string name="update_available">Nueva actualización disponible</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -171,7 +171,7 @@
     <string name="save_shuffle_and_repeat_mode">نگه‌داری حالت تصادفی و تکرار</string>
     <string name="skip_silent">رد کردن سکوت</string>
     <string name="skip_no_music_part">رد کردن بخش بدون موسیقی</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">زمان تمام
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">(%1$d) زمان تمام
     شد، اتصال اینترنت را بررسی کنید</string>
     <string name="save_last_played">نگه‌داری آخرین پخش شده</string>
     <string name="save_last_played_track_and_queue">نگه‌داری آخرین آهنگ پخش شده و صف</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">Muista sekoituksen ja toistamisen tila</string>
     <string name="skip_silent">Ohita hiljaisuus</string>
     <string name="skip_no_music_part">Ohita osa ilman musiikkia</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Aikakatkaisu, tarkista internet-yhteys</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Aikakatkaisu, tarkista internet-yhteys (%1$d)</string>
     <string name="save_last_played">Muista viimeksi soitettu</string>
     <string name="save_last_played_track_and_queue">Muista viimeksi toistettu kappale ja jono</string>
     <string name="update_available">Uusi päivitys on saatavilla</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">Enregistrer les modes aléatoire et répétition</string>
     <string name="skip_silent">Sauter le silence</string>
     <string name="skip_no_music_part">Sauter la partie sans musique</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Délais écoulé. Vérifiez votre connexion internet.</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Délais écoulé. Vérifiez votre connexion internet. (%1$d)</string>
     <string name="save_last_played">Sauvegarder la dernière lecture</string>
     <string name="save_last_played_track_and_queue">Sauvegarder le dernier titre joué et la file d\'attente</string>
     <string name="update_available">Nouvelle mise à jour disponible !</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -163,7 +163,7 @@
     <string name="save_shuffle_and_repeat_mode">शफल और दोहराव मोड सहेजें</string>
     <string name="skip_silent">मौन को छोड़ें</string>
     <string name="skip_no_music_part">संगीत रहित भाग को छोड़ें</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">टाइम आउट, इंटरनेट कनेक्शन जांचें</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">टाइम आउट, इंटरनेट कनेक्शन जांचें (%1$d)</string>
     <string name="save_last_played">अंतिम चलाया गया सहेजें</string>
     <string name="save_last_played_track_and_queue">अंतिम चलाया गया गाना और कतार सहेजें</string>
     <string name="update_available">नया अपडेट उपलब्ध है</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">Simpan mode acak dan ulangi</string>
     <string name="skip_silent">Lewati Senyap</string>
     <string name="skip_no_music_part">Lewati Musik Bagian Kosong</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Waktu habis, periksa koneksi internet</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Waktu habis, periksa koneksi internet (%1$d)</string>
     <string name="save_last_played">Simpan Terakhir Diputar</string>
     <string name="save_last_played_track_and_queue">Menyimpan lagu yang terakhir diputar dan antrean</string>
     <string name="update_available">Pembaruan baru tersedia</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">Salva la modalità casuale e di ripetizione</string>
     <string name="skip_silent">Salta silenzioso</string>
     <string name="skip_no_music_part">Non saltare alcuna parte musicale</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Timeout, controlla la connessione Internet</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Timeout, controlla la connessione Internet (%1$d)</string>
     <string name="save_last_played">Salva l\'ultima riproduzione</string>
     <string name="save_last_played_track_and_queue">Salva l\'ultima traccia riprodotta e la coda</string>
     <string name="update_available">Nuovo aggiornamento disponibile</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">שמור מצב ערבוב וחזרה</string>
     <string name="skip_silent">דלג על שקט</string>
     <string name="skip_no_music_part">לא לדלג על אף קטע מוזיקה</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">פסק זמן, בדוק את החיבור לאינטרנט</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">(%1$d) פסק זמן, בדוק את החיבור לאינטרנט</string>
     <string name="save_last_played">שמור הושמע לאחרונה</string>
     <string name="save_last_played_track_and_queue">שמור את הרצועה האחרונה שהושמעה ואת התור</string>
     <string name="update_available">עדכון חדש זמין</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">シャッフルとリピートの設定を保存</string>
     <string name="skip_silent">無音部分を飛ばす</string>
     <string name="skip_no_music_part">音楽でない部分を飛ばします</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">タイムアウトしました。ネット接続を確認してください</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">タイムアウトしました。ネット接続を確認してください (%1$d)</string>
     <string name="save_last_played">最後に再生したものを保存</string>
     <string name="save_last_played_track_and_queue">最後に再生した曲とキューを保存</string>
     <string name="update_available">最新版があります</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">Shuffle en herhaal modus opslaan</string>
     <string name="skip_silent">Stilte Overslaan</string>
     <string name="skip_no_music_part">Geen muziekonderdeel overslaan</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Time-out, controleer de internetverbinding</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Time-out, controleer de internetverbinding (%1$d)</string>
     <string name="save_last_played">Sla laatst gespeeld op</string>
     <string name="save_last_played_track_and_queue">Sla laatst gespeelde nummer en wachtrij op</string>
     <string name="update_available">Nieuwe update beschikbaar</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">Zapisz tryb losowania i powtarzania</string>
     <string name="skip_silent">Pomiń wyciszenie</string>
     <string name="skip_no_music_part">Pomiń brak części muzycznej</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Przekroczono czas oczekiwania, sprawdź połączenie internetowe</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Przekroczono czas oczekiwania, sprawdź połączenie internetowe (%1$d)</string>
     <string name="save_last_played">Zapisz ostatnio odtwarzane</string>
     <string name="save_last_played_track_and_queue">Zapisz ostatnio odtwarzany utwór i kolejkę</string>
     <string name="update_available">Dostępna jest nowa aktualizacja</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">Salvar modo aleatório e de repetição</string>
     <string name="skip_silent">Pular Silencioso</string>
     <string name="skip_no_music_part">Pular parte da silenciosa da música</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Tempo esgotado, verifique sua conexão com a internet</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Tempo esgotado, verifique sua conexão com a internet (%1$d)</string>
     <string name="save_last_played">Salvar Última Reprodução</string>
     <string name="save_last_played_track_and_queue">Salvar a última faixa e fila reproduzidas</string>
     <string name="update_available">Nova atualização disponível</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">Сохранить перемешивание и повтор</string>
     <string name="skip_silent">Пропустить без звука</string>
     <string name="skip_no_music_part">Пропустить без музыкальной части</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Тайм-аут, проверьте подключение к Интернету</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Тайм-аут, проверьте подключение к Интернету (%1$d)</string>
     <string name="save_last_played">Сохранить последнюю воспроизводимую</string>
     <string name="save_last_played_track_and_queue">Сохранить последний воспроизведенный трек и очередь</string>
     <string name="update_available">Доступно новое обновление</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">บันทึกโหมดสุ่มและเล่นซ้ำ</string>
     <string name="skip_silent">ข้ามเสียงเงียบ</string>
     <string name="skip_no_music_part">ไม่ข้ามส่วนดนตรี</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">หมดเวลาการเชื่อต่อ ตรวจสอบการเชื่อมต่ออินเตอร์เน็ต</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">หมดเวลาการเชื่อต่อ ตรวจสอบการเชื่อมต่ออินเตอร์เน็ต (%1$d)</string>
     <string name="save_last_played">บันทึกการเล่นครั้งล่าสุด</string>
     <string name="save_last_played_track_and_queue">บันทึกเพลงและคิวที่เล่นล่าสุด</string>
     <string name="update_available">อัปเดตใหม่พร้อมใช้งานแล้ว</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">Karıştır ve tekrarla modunu kaydet</string>
     <string name="skip_silent">Sessizliği Atla</string>
     <string name="skip_no_music_part">Müziksiz bölümü atla</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Zaman aşımı, internet bağlantısını kontrol edin</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Zaman aşımı, internet bağlantısını kontrol edin (%1$d)</string>
     <string name="save_last_played">Son Oynatılanı Kaydet</string>
     <string name="save_last_played_track_and_queue">Son çalınan parçayı ve sırayı kaydet</string>
     <string name="update_available">Yeni güncelleme mevcut</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">Зберегти режим перемішування та повтору</string>
     <string name="skip_silent">Пропустити мовчання</string>
     <string name="skip_no_music_part">Пропустити частини без музики</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Вичерпано час очікування, перевірте інтернет-з\'єднання</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Вичерпано час очікування, перевірте інтернет-з\'єднання (%1$d)</string>
     <string name="save_last_played">Зберегти останнє відтворене</string>
     <string name="save_last_played_track_and_queue">Зберегти останній відтворений трек і чергу</string>
     <string name="update_available">Доступне нове оновлення</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">Lưu chế độ trộn và phát lại</string>
     <string name="skip_silent">Bỏ qua im lặng</string>
     <string name="skip_no_music_part">Bỏ qua phần không có nhạc</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Quá thời gian, kiểm qua kết nối internet</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Quá thời gian, kiểm qua kết nối internet (%1$d)</string>
     <string name="save_last_played">Lưu phiên phát lại cuối cùng</string>
     <string name="save_last_played_track_and_queue">Lưu bài hát đang phát và danh sách chờ cuối cùng</string>
     <string name="update_available">Phiên bản mới có sẵn</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">保存随机和重复模式</string>
     <string name="skip_silent">跳过静音</string>
     <string name="skip_no_music_part">跳过没有音乐部分</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">超时，检查网络连接</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">超时，检查网络连接 (%1$d)</string>
     <string name="save_last_played">保存上次播放</string>
     <string name="save_last_played_track_and_queue">保存上次播放的曲目和队列</string>
     <string name="update_available">有可用的更新</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -169,7 +169,7 @@
     <string name="save_shuffle_and_repeat_mode">Save shuffle and repeat mode</string>
     <string name="skip_silent">Skip Silent</string>
     <string name="skip_no_music_part">Skip no music part</string>
-    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Time out, check internet connection</string>
+    <string name="time_out_check_internet_connection_or_change_piped_instance_in_settings">Time out, check internet connection (%1$d)</string>
     <string name="save_last_played">Save Last Played</string>
     <string name="save_last_played_track_and_queue">Save last played track and queue</string>
     <string name="update_available">New update available</string>


### PR DESCRIPTION
- Toast should not show if app is in background
- Add player's error code to log & toast messages

Issue: If app's set to not allow background data usage, when app is in background with music already stopped (either by user or by bluetooth speaker), it was continuously showing a toast saying "Time out..." out of no where, even hours later.