### PR TITLE
Make Musixmatch UserId regex less restrictive

### DIFF
--- a/app/src/main/java/com/maxrave/simpmusic/ui/screen/login/MusixmatchLoginScreen.kt
+++ b/app/src/main/java/com/maxrave/simpmusic/ui/screen/login/MusixmatchLoginScreen.kt
@@ -57,7 +57,7 @@ fun MusixmatchLoginScreen(
     ) {
         if (debugInfo.isNotEmpty()) {
 
-            val fullUserIdRegex = """\[UserId\]:\s*(mxm:[a-f0-9]+)""".toRegex()
+            val fullUserIdRegex = """\[UserId\]:\s*([a-zA-Z0-9]+:[a-f0-9]+)""".toRegex()
             val fullUserId = fullUserIdRegex.find(debugInfo)?.groupValues?.get(1)
 
             val userTokenRegex = """\[UserToken\]:\s*([a-f0-9]+)""".toRegex()


### PR DESCRIPTION
UserId doesn't always starts with mxm (mine starts with g2 instead), and it isn't obvious why logon doesn't work without checking the code; 
This commit should make regex less restrictive.