### PR TITLE
Fix log in warning message for clarity

### DIFF
--- a/core/common/src/main/res/values/strings.xml
+++ b/core/common/src/main/res/values/strings.xml
@@ -362,7 +362,7 @@
     <string name="loading">Loading</string>
     <string name="updating">Updating</string>
     <string name="go_to_log_in_page">Go to log in page</string>
-    <string name="log_in_warning">YouTube Music now requires you to log in to stream music, Piped Instance sometime can\'t work too. You should log in to YouTube to get better experience with SimpMusic.</string>
+    <string name="log_in_warning">YouTube Music now requires you to log in to stream music, Piped Instances sometimes can\'t work too. You should log in to YouTube to get a better experience with SimpMusic.</string>
     <string name="spotify_canvas_cache">Spotify Canvas Cache</string>
     <string name="clear_canvas_cache">Clear canvas cache</string>
     <string name="proxy">Proxy</string>


### PR DESCRIPTION
Changed the log in message to mention "Piped Instances" instead of "Piped Instance". "sometime" (eventually) has also been changed to "sometimes" (at times). The word "a" has also been added, since your experience with the app is just one.