### PR TITLE
Fix GStreamer path configuration for Windows desktop builds

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -455,5 +455,13 @@ afterEvaluate {
             jvmArgs("--add-opens", "java.desktop/sun.lwawt=ALL-UNNAMED")
             jvmArgs("--add-opens", "java.desktop/sun.lwawt.macosx=ALL-UNNAMED")
         }
+        
+        // Set GStreamer path for Windows
+        if (System.getProperty("os.name").contains("Windows")) {
+            val gstreamerRoot = "C:\\Program Files\\gstreamer\\1.0\\msvc_x86_64"
+            val gstreamerBin = "$gstreamerRoot\\bin"
+            environment("GSTREAMER_1_0_ROOT_MSVC_X86_64", gstreamerRoot)
+            systemProperty("gstreamer.path", gstreamerBin)
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the GStreamer library loading issue on Windows by configuring the correct path in build.gradle.kts.

## Changes
- Add Windows-specific GStreamer path detection in build.gradle.kts
- Set GSTREAMER_1_0_ROOT_MSVC_X86_64 environment variable
- Set gstreamer.path system property to point to bin directory

## Fixes
- Resolves 'Could not load library: gstreamer' error on Windows
- Allows desktop application to properly initialize GStreamer on Windows systems

## Testing
- Tested on Windows with GStreamer installed at default location (C:\Program Files\gstreamer\1.0\msvc_x86_64)
- Application successfully compiles and runs with GStreamer properly loaded