### PR TITLE
Fix: Playing Next Item in download folder

### DIFF
--- a/app/src/main/java/com/maxrave/simpmusic/viewModel/LibraryDynamicPlaylistViewModel.kt
+++ b/app/src/main/java/com/maxrave/simpmusic/viewModel/LibraryDynamicPlaylistViewModel.kt
@@ -110,7 +110,7 @@ class LibraryDynamicPlaylistViewModel(
         loadMediaItem(
             playTrack.toTrack(),
             Config.PLAYLIST_CLICK,
-            0,
+            targetList.indexOf(playTrack).coerceAtLeast(0),
         )
     }
 }


### PR DESCRIPTION
When i was using with downloaded songs i found that even if if play second last song after that if i press forward button it always play 2 song because initially it considered index 0. I changed this and pass actual index of the download song