### PR TITLE
Add 5-second rewind and forward controls for songs and podcasts

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/PlayerControlLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/PlayerControlLayout.kt
@@ -13,10 +13,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Forward5
 import androidx.compose.material.icons.rounded.PauseCircle
 import androidx.compose.material.icons.rounded.PlayCircle
 import androidx.compose.material.icons.rounded.Repeat
 import androidx.compose.material.icons.rounded.RepeatOne
+import androidx.compose.material.icons.rounded.Replay5
 import androidx.compose.material.icons.rounded.Shuffle
 import androidx.compose.material.icons.rounded.SkipNext
 import androidx.compose.material.icons.rounded.SkipPrevious
@@ -91,6 +93,29 @@ fun PlayerControlLayout(
                 modifier =
                     Modifier
                         .background(transparent)
+                        .size(smallIcon.second)
+                        .aspectRatio(1f)
+                        .clip(
+                            CircleShape,
+                        )
+                        .clickable {
+                            onUIEvent(UIEvent.Backward5)
+                        },
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Replay5,
+                    tint = Color.White,
+                    contentDescription = "",
+                    modifier = Modifier.size(smallIcon.first),
+                )
+            }
+        }
+        Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
+            Box(
+                modifier =
+                    Modifier
+                        .background(transparent)
                         .size(mediumIcon.second)
                         .aspectRatio(1f)
                         .clip(
@@ -106,6 +131,29 @@ fun PlayerControlLayout(
                 Icon(
                     imageVector = Icons.Rounded.SkipPrevious,
                     tint = if (controllerState.isPreviousAvailable) Color.White else Color.Gray,
+                    contentDescription = "",
+                    modifier = Modifier.size(mediumIcon.first),
+                )
+            }
+        }
+        Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
+            Box(
+                modifier =
+                    Modifier
+                        .background(transparent)
+                        .size(mediumIcon.second)
+                        .aspectRatio(1f)
+                        .clip(
+                            CircleShape,
+                        )
+                        .clickable {
+                            onUIEvent(UIEvent.Backward)
+                        },
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Replay10,
+                    tint = Color.White,
                     contentDescription = "",
                     modifier = Modifier.size(mediumIcon.first),
                 )
@@ -143,6 +191,29 @@ fun PlayerControlLayout(
                         )
                     }
                 }
+            }
+        }
+        Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
+            Box(
+                modifier =
+                    Modifier
+                        .background(transparent)
+                        .size(mediumIcon.second)
+                        .aspectRatio(1f)
+                        .clip(
+                            CircleShape,
+                        )
+                        .clickable {
+                            onUIEvent(UIEvent.Forward5)
+                        },
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Forward5,
+                    tint = Color.White,
+                    contentDescription = "",
+                    modifier = Modifier.size(mediumIcon.first),
+                )
             }
         }
         Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/SharedViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/SharedViewModel.kt
@@ -770,6 +770,30 @@ class SharedViewModel(
                     dataStoreManager.setPlayerVolume(newVolume)
                     mediaPlayerHandler.onPlayerEvent(PlayerEvent.UpdateVolume(newVolume))
                 }
+
+                UIEvent.Forward5 -> {
+                    val current = timeline.value.current
+                    val total = timeline.value.total
+                    if (total > 0) {
+                        val newProgress = (current + 5000).coerceAtMost(total)
+                        val progressPercent = (newProgress.toFloat() / total.toFloat()) * 100f
+                        mediaPlayerHandler.onPlayerEvent(
+                            PlayerEvent.UpdateProgress(progressPercent),
+                        )
+                    }
+                }
+
+                UIEvent.Backward5 -> {
+                    val current = timeline.value.current
+                    val total = timeline.value.total
+                    if (total > 0) {
+                        val newProgress = (current - 5000).coerceAtLeast(0)
+                        val progressPercent = (newProgress.toFloat() / total.toFloat()) * 100f
+                        mediaPlayerHandler.onPlayerEvent(
+                            PlayerEvent.UpdateProgress(progressPercent),
+                        )
+                    }
+                }
             }
         }
 
@@ -1626,6 +1650,10 @@ sealed class UIEvent {
     ) : UIEvent()
 
     data object ToggleLike : UIEvent()
+
+    data object Forward5 : UIEvent()
+
+    data object Backward5 : UIEvent()
 }
 
 enum class LyricsProvider {


### PR DESCRIPTION
### Summary
Added 5-second rewind and forward support to the media player.

### Changes
- Added rewind and forward buttons to the player UI
- Implemented ±5 second seek logic

### Testing
- Verified UI controls trigger correct seek behaviour
- Tested it on an Android device. Model - Samsung A35

**Below is how the implementation looks**

<img width="376" height="804" alt="Rewind and Forward - Song" src="https://github.com/user-attachments/assets/eeb98223-48fa-4d00-8e28-d16b06e09eef" />
<img width="370" height="811" alt="Rewind and Forward - Podcast" src="https://github.com/user-attachments/assets/27c77110-7781-41be-b604-72e7dd964d31" />

## Note
This is my first open-source contribution—thanks a lot for taking the time to review it!  
I am a big fan of this project. Thank you for all the work you’ve put into building and maintaining this project.  
I’m also planning to extend this by adding a 10-second rewind/forward option.
