### PR TITLE
fix(desktop): add GStreamer library path for macOS Homebrew installations

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -285,6 +285,14 @@ afterEvaluate {
             jvmArgs("--add-opens", "java.desktop/sun.awt=ALL-UNNAMED")
             jvmArgs("--add-opens", "java.desktop/sun.lwawt=ALL-UNNAMED")
             jvmArgs("--add-opens", "java.desktop/sun.lwawt.macosx=ALL-UNNAMED")
+            // GStreamer library path for Homebrew installations
+            // Apple Silicon uses /opt/homebrew, Intel Macs use /usr/local
+            val homebrewLib = if (System.getProperty("os.arch") == "aarch64") {
+                "/opt/homebrew/lib"
+            } else {
+                "/usr/local/lib"
+            }
+            jvmArgs("-Djna.library.path=$homebrewLib")
         }
     }
 


### PR DESCRIPTION
## Summary

Desktop app crashes on macOS when GStreamer is installed via Homebrew because JNA cannot find the native library.

**Error:**
```
java.lang.IllegalStateException: Unable to load native library 'gstreamer-1.0'
Caused by: java.lang.UnsatisfiedLinkError: Unable to load library 'gstreamer-1.0':
  dlopen(libgstreamer-1.0.dylib, 0x0001): tried: 'libgstreamer-1.0.dylib' (no such file)
```

## Changes

- Added `-Djna.library.path` JVM argument for macOS in `composeApp/build.gradle.kts`
- Supports both Apple Silicon (`/opt/homebrew/lib`) and Intel Macs (`/usr/local/lib`)

## Test plan

1. Install GStreamer via Homebrew: `brew install gstreamer`
2. Run the desktop app: `./gradlew :composeApp:run`
3. App should launch without the library loading crash

---
🤖 Generated with [Claude Code](https://claude.ai/code)