### PR TITLE
feat: add sort options to Downloads screen

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ar/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ar/strings.xml
@@ -266,6 +266,12 @@
     <string name="sort">فرز</string>
     <string name="older_first">إظهار الأقدم أولاً</string>
     <string name="newer_first">إظهار الأحدث أولاً</string>
+    <string name="download_sort_title_asc">العنوان (أ-ي)</string>
+    <string name="download_sort_title_desc">العنوان (ي-أ)</string>
+    <string name="download_sort_date_newest">الأحدث أولاً</string>
+    <string name="download_sort_date_oldest">الأقدم أولاً</string>
+    <string name="download_sort_artist_asc">الفنان (أ-ي)</string>
+    <string name="download_sort_artist_desc">الفنان (ي-أ)</string>
     <string name="added_date">تاريخ الإضافة</string>
     <string name="credit_app">تطبيق موسيقي بسيط يستخدم YouTube Music for backend \n\nSimpMusic هو مشروع مفتوح المصدر لبث الموسيقى من YouTube و YouTube Music بدون إعلانات وتتبُّع. يوفر SimpMusic العديد من الميزات:\n\n - بث الموسيقى \n - مزامنة كلمات الاغاني\n - تخصيص البيانات\n - إلخ… \n\nSimpMusic مجاني دائمًا وبدون إعلانات\n\nتم تطويره بـ ❤️ بواسطة Tuan Minh Nguyen Duc (maxrave-dev)</string>
     <string name="issue_tracker">متعقب المشاكل</string>

--- a/composeApp/src/commonMain/composeResources/values-az/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-az/strings.xml
@@ -256,6 +256,12 @@
     <string name="free_space">Boş yer</string>
     <string name="suggest">Tövsiyə</string>
     <string name="reload">Təkrar yüklə</string>
+    <string name="download_sort_title_asc">Başlıq (A-Z)</string>
+    <string name="download_sort_title_desc">Başlıq (Z-A)</string>
+    <string name="download_sort_date_newest">Ən yenilər əvvəl</string>
+    <string name="download_sort_date_oldest">Ən köhnələr əvvəl</string>
+    <string name="download_sort_artist_asc">Ifacı (A-Z)</string>
+    <string name="download_sort_artist_desc">Ifacı (Z-A)</string>
     <string name="added_date">Əlavə edilmə tarixi</string>
     <string name="credit_app">Geri çıxış üçün YouTube Music işlədən sadə musiqi tətbiqi \n\nSimpMusic reklam və izləmə olmadan YouTube və YouTube Music-dən musiqi yayımlamaq üçün açıq mənbə layihədir. SimpMusic bir çox xüsusiyyətləri təmin edir:\n\n - Musiqi yayımı\n - Sinxronlaşdırılan lirika\n - Məlumatları fərdiləşdir\n - və s... \n\nSimpMusic həmişə pulsuzdur və reklam yoxdur\n\nTuan Minh Nguyen Duc (maxrave-dev) ❤️- ilə qurur</string>
     <string name="issue_tracker">Problem İzləyici</string>

--- a/composeApp/src/commonMain/composeResources/values-bg/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-bg/strings.xml
@@ -256,6 +256,12 @@
     <string name="free_space">Свободно пространство</string>
     <string name="suggest">Предложение</string>
     <string name="reload">Презареди</string>
+    <string name="download_sort_title_asc">Заглавие (А-Я)</string>
+    <string name="download_sort_title_desc">Заглавие (Я-А)</string>
+    <string name="download_sort_date_newest">Най-нови първо</string>
+    <string name="download_sort_date_oldest">Най-стари първо</string>
+    <string name="download_sort_artist_asc">Изпълнител (А-Я)</string>
+    <string name="download_sort_artist_desc">Изпълнител (Я-А)</string>
     <string name="added_date">Дата на добавяне</string>
     <string name="credit_app">Опростено приложение за музика, което използва YouTube Music за бекенд \n\nSimpMusic е проект с отворен код, който стриймва музика от YouTube и YouTube Music без реклами и проследяване. SimpMusic идва с много функции:\n\n - Стрийминг \n - Текстове\n - Персонализиране на данните\n - и т. н… \n\nSimpMusic е безплатен и без реклами\n\nBuild с ❤️ от Tuan Minh Nguyen Duc (maxrave-dev)</string>
     <string name="issue_tracker">Тракър на задачи</string>

--- a/composeApp/src/commonMain/composeResources/values-ca/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ca/strings.xml
@@ -265,6 +265,12 @@
     <string name="sort">Ordena</string>
     <string name="older_first">Més antics primer</string>
     <string name="newer_first">Més nous primer</string>
+    <string name="download_sort_title_asc">Títol (A-Z)</string>
+    <string name="download_sort_title_desc">Títol (Z-A)</string>
+    <string name="download_sort_date_newest">Més nous primer</string>
+    <string name="download_sort_date_oldest">Més antics primer</string>
+    <string name="download_sort_artist_asc">Artista (A-Z)</string>
+    <string name="download_sort_artist_desc">Artista (Z-A)</string>
     <string name="added_date">Data afegida</string>
     <string name="credit_app">Una aplicació de música senzilla que utilitza YouTube Music per al backend \n\nSimpMusic és un projecte de codi obert per reproduir música de YouTube i YouTube Music sense anuncis ni seguiment. SimpMusic ofereix moltes funcions:\n\n - Reproducció de música en temps real \n - Lletres sincronitzades\n - Personalització de dades\n - etc... \n\nSimpMusic sempre és gratuït i sense anuncis\n\nCrea amb ❤️ de Tuan Minh Nguyen Duc (maxrave -dev)</string>
     <string name="issue_tracker">Detector de problemes</string>

--- a/composeApp/src/commonMain/composeResources/values-de/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-de/strings.xml
@@ -270,6 +270,12 @@
     <string name="sort">Sortieren</string>
     <string name="older_first">Ältere zuerst</string>
     <string name="newer_first">Neue zuerst</string>
+    <string name="download_sort_title_asc">Titel (A-Z)</string>
+    <string name="download_sort_title_desc">Titel (Z-A)</string>
+    <string name="download_sort_date_newest">Neueste zuerst</string>
+    <string name="download_sort_date_oldest">Älteste zuerst</string>
+    <string name="download_sort_artist_asc">Künstler (A-Z)</string>
+    <string name="download_sort_artist_desc">Künstler (Z-A)</string>
     <string name="added_date">Datum hinzugefügt</string>
     <string name="credit_app">Eine einfache Musik-App mit YouTube Music als Backend \n\nSimpMusic ist ein Open-Source-Projekt zum Streamen von Musik von YouTube und YouTube Music ohne Werbung und Tracking. SimpMusic bietet viele Funktionen:\n\n - Musik streamen \n - Synchronisierte Liedtexte\n - Daten personalisieren\n - etc… \n\nSimpMusic ist immer kostenlos und ohne Werbung\n\nErstellen Sie mit ❤️ von Tuan Minh Nguyen Duc (maxrave-dev)</string>
     <string name="issue_tracker">Issue-Tracker</string>

--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -271,6 +271,12 @@
     <string name="sort">Clasificar</string>
     <string name="older_first">Primero antiguo</string>
     <string name="newer_first">Primero nuevo</string>
+    <string name="download_sort_title_asc">Título (A-Z)</string>
+    <string name="download_sort_title_desc">Título (Z-A)</string>
+    <string name="download_sort_date_newest">Más recientes primero</string>
+    <string name="download_sort_date_oldest">Más antiguos primero</string>
+    <string name="download_sort_artist_asc">Artista (A-Z)</string>
+    <string name="download_sort_artist_desc">Artista (Z-A)</string>
     <string name="added_date">Fecha añadida</string>
     <string name="credit_app">Una aplicación de música sencilla que utiliza YouTube Music como backend \n\nSimpMusic es un proyecto de código abierto para transmitir música desde YouTube y YouTube Music sin anuncios ni seguimiento. SimpMusic ofrece muchas funciones:\n\n - Transmisión de música \n - Letras sincronizadas\n - Personalizar datos\n - etc... \n\nSimpMusic es siempre gratuito y sin anuncios\n\nCompilado con ❤️ de Tuan Minh Nguyen Duc (maxrave-dev)</string>
     <string name="issue_tracker">Rastreador de errores</string>

--- a/composeApp/src/commonMain/composeResources/values-fa/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fa/strings.xml
@@ -279,6 +279,12 @@
     <string name="sort">ترتیب</string>
     <string name="older_first">ابتدا قدیمی تر</string>
     <string name="newer_first">ابتدا جدیدتر</string>
+    <string name="download_sort_title_asc">عنوان (الف-ی)</string>
+    <string name="download_sort_title_desc">عنوان (ی-الف)</string>
+    <string name="download_sort_date_newest">جدیدترین ابتدا</string>
+    <string name="download_sort_date_oldest">قدیمی‌ترین ابتدا</string>
+    <string name="download_sort_artist_asc">هنرمند (الف-ی)</string>
+    <string name="download_sort_artist_desc">هنرمند (ی-الف)</string>
     <string name="added_date">تاریخ افزوده شدن</string>
     <string name="credit_app">یک برنامه موسیقی ساده که از هسته یوتیوب موزیک بهره میبرد\n\nSimpMusic یک پروژه متن‌باز برای پخش موسیقی از یوتیوب و یوتیوب موزیک بدون آگهی و ردیابی است. SimpMusic ویژگی‌های زیادی ارائه می‌دهد:\n\n - پخش موسیقی \n - متن ترانه همگام‌سازی شده\n - داده‌های شخصی‌سازی شده\n - و غیره… \n\nSimpMusic همیشه رایگان و بدون آگهی است\n\nساخته شده با ❤️ از Tuan Minh Nguyen Duc (maxrave-dev)</string>
     <string name="issue_tracker">ردیاب مشکلات</string>

--- a/composeApp/src/commonMain/composeResources/values-fi/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fi/strings.xml
@@ -256,6 +256,12 @@
     <string name="suggest">Ehdotus</string>
     <string name="reload">Lataa uudelleen</string>
     <string name="newer_first">Uusimmat ensin</string>
+    <string name="download_sort_title_asc">Otsikko (A-Ö)</string>
+    <string name="download_sort_title_desc">Otsikko (Ö-A)</string>
+    <string name="download_sort_date_newest">Uusimmat ensin</string>
+    <string name="download_sort_date_oldest">Vanhimmat ensin</string>
+    <string name="download_sort_artist_asc">Artisti (A-Ö)</string>
+    <string name="download_sort_artist_desc">Artisti (Ö-A)</string>
     <string name="added_date">Lisäyspäivämäärä</string>
     <string name="credit_app">Yksinkertainen musiikkisovellus, joka käyttää YouTube Musicin taustajärjestelmää \n\nSimpMusic on avoimen lähdekoodin projekti musiikin suoratoistoon YouTubesta ja YouTube Musicista ilman mainoksia ja seurantaa. SimpMusic tarjoaa monia ominaisuuksia:\n\n - Musiikin suoratoisto \n - Synkronoidut sanoitukset\n - Tietojen mukauttaminen\n - jne… \n\nSimpMusic on aina ilmainen ja vailla mainoksia\n\nTehty ❤️:llä, Tuan Minh Nguyen Duc (maxrave-dev)</string>
     <string name="issue_tracker">Tikettijärjestelmä</string>

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -273,8 +273,8 @@
     <string name="newer_first">Les plus récents d'abord</string>
     <string name="download_sort_title_asc">Titre (A-Z)</string>
     <string name="download_sort_title_desc">Titre (Z-A)</string>
-    <string name="download_sort_date_newest">Plus récents d\u0027abord</string>
-    <string name="download_sort_date_oldest">Plus anciens d\u0027abord</string>
+    <string name="download_sort_date_newest">Plus récents d'abord</string>
+    <string name="download_sort_date_oldest">Plus anciens d'abord</string>
     <string name="download_sort_artist_asc">Artiste (A-Z)</string>
     <string name="download_sort_artist_desc">Artiste (Z-A)</string>
     <string name="added_date">Date d'ajout</string>

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -271,6 +271,12 @@
     <string name="sort">Trier</string>
     <string name="older_first">Les plus anciens d'abord</string>
     <string name="newer_first">Les plus récents d'abord</string>
+    <string name="download_sort_title_asc">Titre (A-Z)</string>
+    <string name="download_sort_title_desc">Titre (Z-A)</string>
+    <string name="download_sort_date_newest">Plus récents d\u0027abord</string>
+    <string name="download_sort_date_oldest">Plus anciens d\u0027abord</string>
+    <string name="download_sort_artist_asc">Artiste (A-Z)</string>
+    <string name="download_sort_artist_desc">Artiste (Z-A)</string>
     <string name="added_date">Date d'ajout</string>
     <string name="credit_app">Une application musicale simple utilisant YouTube Music pour le backend \n\nSimpMusic est un projet open source pour diffuser de la musique à partir de YouTube et YouTube Music sans publicité ni suivi. SimpMusic offre de nombreuses fonctionnalités :\n\n - Streaming de musique \n - Paroles synchronisées\n - Personnaliser les données\n - etc… \n\nSimpMusic est toujours gratuit et sans publicité\n\nConstruit avec ❤️ de Tuan Minh Nguyen Duc (maxrave-dev)</string>
     <string name="issue_tracker">Suivi des problèmes</string>

--- a/composeApp/src/commonMain/composeResources/values-hi/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-hi/strings.xml
@@ -266,6 +266,12 @@
     <string name="sort">क्रम से लगाएं</string>
     <string name="older_first">पुराने पहले</string>
     <string name="newer_first">नए पहले</string>
+    <string name="download_sort_title_asc">शीर्षक (A-Z)</string>
+    <string name="download_sort_title_desc">शीर्षक (Z-A)</string>
+    <string name="download_sort_date_newest">नवीनतम पहले</string>
+    <string name="download_sort_date_oldest">सबसे पुराने पहले</string>
+    <string name="download_sort_artist_asc">कलाकार (A-Z)</string>
+    <string name="download_sort_artist_desc">कलाकार (Z-A)</string>
     <string name="added_date">जोड़ने की तिथि</string>
     <string name="credit_app">बैकएंड के लिए YouTube Music का उपयोग करने वाला एक सरल संगीत ऐप \n\nSimpMusic YouTube और YouTube Music से बिना विज्ञापनों और ट्रैकिंग के संगीत स्ट्रीम करने के लिए एक ओपन सोर्स प्रोजेक्ट है। SimpMusic कई सुविधाएं प्रदान करता है:\n\n - संगीत स्ट्रीमिंग \n - सिंक किए गए गाने के बोल\n - व्यक्तिगत डेटा\n - और बहुत कुछ… \n\nSimpMusic हमेशा मुफ्त और बिना विज्ञापनों के है\n\nतुआन मिन्ह न्गुयेन डक (maxrave-dev) द्वारा ❤️ से बनाया गया</string>
     <string name="issue_tracker">समस्या ट्रैकर</string>

--- a/composeApp/src/commonMain/composeResources/values-in/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-in/strings.xml
@@ -258,6 +258,12 @@
     <string name="free_space">Ruang kosong</string>
     <string name="suggest">Saran</string>
     <string name="reload">Memuat ulang</string>
+    <string name="download_sort_title_asc">Judul (A-Z)</string>
+    <string name="download_sort_title_desc">Judul (Z-A)</string>
+    <string name="download_sort_date_newest">Terbaru dulu</string>
+    <string name="download_sort_date_oldest">Terlama dulu</string>
+    <string name="download_sort_artist_asc">Artis (A-Z)</string>
+    <string name="download_sort_artist_desc">Artis (Z-A)</string>
     <string name="added_date">Tanggal ditambahkan</string>
     <string name="credit_app">Aplikasi musik sederhana yang menggunakan YouTube Music untuk backend \n\nSimpMusic adalah proyek sumber terbuka untuk streaming musik dari YouTube dan YouTube Music tanpa iklan dan pelacakan. SimpMusic menyediakan banyak fitur:\n\n - Streaming musik\n - Lirik yang disinkronkan\n - Personalisasi data\n - dll... \n\nSimpMusic selalu gratis dan tidak ada iklan\n\nDibangun dengan ❤️ oleh Tuan Minh Nguyen Duc (maxrave-dev)</string>
     <string name="issue_tracker">Pelacak Masalah</string>

--- a/composeApp/src/commonMain/composeResources/values-it/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-it/strings.xml
@@ -270,6 +270,12 @@
     <string name="sort">Ordina</string>
     <string name="older_first"></string>
     <string name="newer_first">Prima Più Recente</string>
+    <string name="download_sort_title_asc">Titolo (A-Z)</string>
+    <string name="download_sort_title_desc">Titolo (Z-A)</string>
+    <string name="download_sort_date_newest">Più recenti prima</string>
+    <string name="download_sort_date_oldest">Più vecchi prima</string>
+    <string name="download_sort_artist_asc">Artista (A-Z)</string>
+    <string name="download_sort_artist_desc">Artista (Z-A)</string>
     <string name="added_date">Data aggiunta</string>
     <string name="credit_app">Una semplice app musicale che utilizza YouTube Music come backend \n\nSimpMusic è un progetto open source per lo streaming di musica da YouTube e YouTube Music senza pubblicità e tracciamento. SimpMusic offre molte funzionalità:\n\n - Musica in streaming\n - Testi sincronizzati\n - Personalizza dati\n - ecc... \n\nSimpMusic è sempre gratuito e senza pubblicità\n\nCrea con ❤️ di Tuan Minh Nguyen Duc (maxrave-dev)</string>
     <string name="issue_tracker">Tracker dei problemi</string>

--- a/composeApp/src/commonMain/composeResources/values-iw/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-iw/strings.xml
@@ -258,6 +258,12 @@
     <string name="free_space">מקום פנוי</string>
     <string name="suggest">הצעה</string>
     <string name="reload">טען מחדש</string>
+    <string name="download_sort_title_asc">כותרת (א-ת)</string>
+    <string name="download_sort_title_desc">כותרת (ת-א)</string>
+    <string name="download_sort_date_newest">חדשים ראשון</string>
+    <string name="download_sort_date_oldest">ישנים ראשון</string>
+    <string name="download_sort_artist_asc">אמן (א-ת)</string>
+    <string name="download_sort_artist_desc">אמן (ת-א)</string>
     <string name="added_date">נוסף תאריך</string>
     <string name="credit_app">אפליקציית מוזיקה פשוטה באמצעות YouTube Music עבור backend \n\nSimpMusic הוא פרויקט קוד פתוח להזרמת מוזיקה מ-YouTube ו-YouTube Music ללא מודעות ומעקב. SimpMusic מספקת תכונות רבות:\n\n - הזרמת מוזיקה \n - מילים מסונכרנות\n - התאמה אישית של נתונים\n - אקו… \n\n
 SimpMusic תמיד בחינם וללא פרסומות\n\nבונה מ ❤️מ-Tuan Minh Nguyen Duc (maxrave-dev)</string>

--- a/composeApp/src/commonMain/composeResources/values-ja/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ja/strings.xml
@@ -268,6 +268,12 @@
     <string name="sort">並び替え</string>
     <string name="older_first">古い順</string>
     <string name="newer_first">新しい順</string>
+    <string name="download_sort_title_asc">タイトル (A-Z)</string>
+    <string name="download_sort_title_desc">タイトル (Z-A)</string>
+    <string name="download_sort_date_newest">新しい順</string>
+    <string name="download_sort_date_oldest">古い順</string>
+    <string name="download_sort_artist_asc">アーティスト (A-Z)</string>
+    <string name="download_sort_artist_desc">アーティスト (Z-A)</string>
     <string name="added_date">追加日</string>
     <string name="credit_app">バックエンドに YouTube ミュージックを使用するシンプルな音楽アプリ \n\nSimpMusic は、広告や追跡なしで YouTube や YouTube ミュージックから音楽をストリーミングするオープンソースのプロジェクトです。SimpMusic の豊富な機能:\n\n - 音楽のストリーミング \n - 歌詞の同期\n - あなたに最適化されたデータ\n - など... \n\nSimpMusic は常に無料、そして広告もなしです。\n\nTuan Minh Nguyen Duc (maxrave) が❤️を込めて開発しました</string>
     <string name="issue_tracker">既知の問題一覧</string>

--- a/composeApp/src/commonMain/composeResources/values-ko/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ko/strings.xml
@@ -266,6 +266,12 @@
     <string name="sort">정렬</string>
     <string name="older_first">날짜순</string>
     <string name="newer_first">최신순</string>
+    <string name="download_sort_title_asc">제목 (가-하)</string>
+    <string name="download_sort_title_desc">제목 (하-가)</string>
+    <string name="download_sort_date_newest">최신순</string>
+    <string name="download_sort_date_oldest">오래된순</string>
+    <string name="download_sort_artist_asc">아티스트 (가-하)</string>
+    <string name="download_sort_artist_desc">아티스트 (하-가)</string>
     <string name="added_date">추가한 날짜</string>
     <string name="credit_app">YouTube Music을 백엔드로 사용하는 간단한 음악 앱 \n\nSimpMusic은 광고나 추적 없이 YouTube나 YouTube Music에서 음악을 스트리밍하는 오픈 소스 프로젝트입니다. SimpMusic에서는 다양한 기능들을 이용할 수 있습니다.\n\n - 음악 스트리밍 \n - 가사 싱크\n - 데이터 개인화\n - 기타… \n\nSimpMusic은 항상 무료이며 광고도 없습니다\n\nTuan Minh Nguyen Duc (maxrave-dev)가 ❤️을 담아 만듦</string>
     <string name="issue_tracker">이슈 트래커</string>

--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -212,4 +212,10 @@
     <string name="sync_playlist_warning">SimpMusic maakt automatisch een YouTube-afspeellijst aan. Weet je het zeker?</string>
     <string name="syncing">Synchroniseren</string>
     <string name="unsync_playlist_warning">"Deze afspeellijst de-synchroniseren? Deze afspeellijst zal niet verwijderd worden van YouTube Muziek "</string>
+    <string name="download_sort_title_asc">Titel (A-Z)</string>
+    <string name="download_sort_title_desc">Titel (Z-A)</string>
+    <string name="download_sort_date_newest">Nieuwste eerst</string>
+    <string name="download_sort_date_oldest">Oudste eerst</string>
+    <string name="download_sort_artist_asc">Artiest (A-Z)</string>
+    <string name="download_sort_artist_desc">Artiest (Z-A)</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -255,6 +255,12 @@
     <string name="free_space">Wolne miejsce</string>
     <string name="suggest">Sugestia</string>
     <string name="reload">Przeładować</string>
+    <string name="download_sort_title_asc">Tytuł (A-Z)</string>
+    <string name="download_sort_title_desc">Tytuł (Z-A)</string>
+    <string name="download_sort_date_newest">Najnowsze najpierw</string>
+    <string name="download_sort_date_oldest">Najstarsze najpierw</string>
+    <string name="download_sort_artist_asc">Artysta (A-Z)</string>
+    <string name="download_sort_artist_desc">Artysta (Z-A)</string>
     <string name="added_date">Dodana data</string>
     <string name="credit_app">Prosta aplikacja muzyczna wykorzystująca YouTube Music jako zaplecze \n\nSimpMusic to projekt typu open source umożliwiający strumieniowe przesyłanie muzyki z YouTube i YouTube Music bez reklam i śledzenia. SimpMusic zapewnia wiele funkcji:\n\n – Przesyłanie strumieniowe muzyki \n – Zsynchronizowane teksty\n – Personalizacja danych\n – itp… \n\nSimpMusic jest zawsze darmowy i nie zawiera reklam\n\nTwórz za pomocą ❤️ od Tuan Minh Nguyen Duc (maxrave-dev)</string>
     <string name="issue_tracker">Lista problemow</string>

--- a/composeApp/src/commonMain/composeResources/values-pt/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pt/strings.xml
@@ -267,6 +267,12 @@
     <string name="sort">Ordenar</string>
     <string name="older_first">Mais Antigas Primeiro</string>
     <string name="newer_first">Mais Recentes Primeiro</string>
+    <string name="download_sort_title_asc">Título (A-Z)</string>
+    <string name="download_sort_title_desc">Título (Z-A)</string>
+    <string name="download_sort_date_newest">Mais recentes primeiro</string>
+    <string name="download_sort_date_oldest">Mais antigos primeiro</string>
+    <string name="download_sort_artist_asc">Artista (A-Z)</string>
+    <string name="download_sort_artist_desc">Artista (Z-A)</string>
     <string name="added_date">Data adicionada</string>
     <string name="credit_app">A simple music app using YouTube Music for backend \n\nSimpMusic is an open source project to stream music from YouTube and YouTube Music without ads and tracking. SimpMusic provides many features:\n\n - Streaming music \n - Synced lyrics\n - Personalize data\n - etc… \n\nSimpMusic is always free and no ads\n\nBuild with ❤️ from Tuan Minh Nguyen Duc (maxrave-dev)</string>
     <string name="issue_tracker">Rastreador de problemas</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -270,6 +270,12 @@
     <string name="sort">Сортировать</string>
     <string name="older_first">Сначала старые</string>
     <string name="newer_first">Сначала новые</string>
+    <string name="download_sort_title_asc">Название (А-Я)</string>
+    <string name="download_sort_title_desc">Название (Я-А)</string>
+    <string name="download_sort_date_newest">Сначала новые</string>
+    <string name="download_sort_date_oldest">Сначала старые</string>
+    <string name="download_sort_artist_asc">Исполнитель (А-Я)</string>
+    <string name="download_sort_artist_desc">Исполнитель (Я-А)</string>
     <string name="added_date">Дата добавления</string>
     <string name="credit_app">Простое музыкальное приложение, использующее YouTube Music в качестве серверной части. \n\nSimpMusic — это проект с открытым исходным кодом для потоковой передачи музыки с YouTube и YouTube Music без рекламы и отслеживания. SimpMusic предоставляет множество функций:\n\n - Потоковое воспроизведение музыки \n - Синхронизированные тексты песен\n - Персонализация данных\n - и т. д. \n\nSimpMusic бесплатен и без рекламы\n\nСоздал с ❤️ Туан Минь Нгуен Дык (maxrave-dev)</string>
     <string name="issue_tracker">Трекер проблем</string>

--- a/composeApp/src/commonMain/composeResources/values-th/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-th/strings.xml
@@ -266,6 +266,12 @@
     <string name="sort">เรียงลำดับ</string>
     <string name="older_first">เรียงจากเก่าไปใหม่</string>
     <string name="newer_first">เรียงจากใหม่ไปเก่า</string>
+    <string name="download_sort_title_asc">ชื่อเพลง (ก-ฮ)</string>
+    <string name="download_sort_title_desc">ชื่อเพลง (ฮ-ก)</string>
+    <string name="download_sort_date_newest">ใหม่สุดก่อน</string>
+    <string name="download_sort_date_oldest">เก่าสุดก่อน</string>
+    <string name="download_sort_artist_asc">ศิลปิน (ก-ฮ)</string>
+    <string name="download_sort_artist_desc">ศิลปิน (ฮ-ก)</string>
     <string name="added_date">เพิ่มวันที่</string>
     <string name="credit_app">แอปเพลงง่ายๆ ที่ใช้ YouTube Music สำหรับแบ็กเอนด์ \n\nSimpMusic เป็นโครงการโอเพ่นซอร์สสำหรับสตรีมเพลงจาก YouTube และ YouTube Music โดยไม่มีโฆษณาและการติดตาม SimpMusic มีคุณสมบัติมากมาย:\n\n - สตรีมเพลง \n - เนื้อเพลงที่ซิงค์กัน\n - ปรับแต่งข้อมูล\n - ฯลฯ…\n\nSimpMusic ฟรีเสมอและไม่มีโฆษณา\n\nสร้างด้วย ❤️ จาก Tuan Minh Nguyen Duc (maxrave-dev)</string>
     <string name="issue_tracker">ติดตามปัญหา</string>

--- a/composeApp/src/commonMain/composeResources/values-tr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-tr/strings.xml
@@ -266,6 +266,12 @@
     <string name="sort">Sırala</string>
     <string name="older_first">Eskiden Yeniye</string>
     <string name="newer_first">Yeniden Eskiye</string>
+    <string name="download_sort_title_asc">Başlık (A-Z)</string>
+    <string name="download_sort_title_desc">Başlık (Z-A)</string>
+    <string name="download_sort_date_newest">En yeniler önce</string>
+    <string name="download_sort_date_oldest">En eskiler önce</string>
+    <string name="download_sort_artist_asc">Sanatçı (A-Z)</string>
+    <string name="download_sort_artist_desc">Sanatçı (Z-A)</string>
     <string name="added_date">Tarih eklendi</string>
     <string name="credit_app">Arka uç olarak YouTube Music'i kullanan basit bir müzik uygulaması \n\nSimpMusic, reklamlar ve izleme olmadan YouTube ve YouTube Music'ten müzik akışı sağlayan açık kaynaklı bir projedir. SimpMusic birçok özellik sunar:\n\n - Müzik akışı \n - Senkronize şarkı sözleri\n - Verileri kişiselleştirin\n - vb… \n\nSimpMusic her zaman ücretsizdir ve reklam içermez\n\nTuan Minh Nguyen Duc'tan ❤️ ile oluşturun (maxrave-dev)</string>
     <string name="issue_tracker">Sorun Takibi</string>

--- a/composeApp/src/commonMain/composeResources/values-uk/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-uk/strings.xml
@@ -270,6 +270,12 @@
     <string name="sort">Упорядкувати</string>
     <string name="older_first">Спочатку старіші</string>
     <string name="newer_first">Спочатку новіші</string>
+    <string name="download_sort_title_asc">Назва (А-Я)</string>
+    <string name="download_sort_title_desc">Назва (Я-А)</string>
+    <string name="download_sort_date_newest">Спочатку новіші</string>
+    <string name="download_sort_date_oldest">Спочатку старіші</string>
+    <string name="download_sort_artist_asc">Виконавець (А-Я)</string>
+    <string name="download_sort_artist_desc">Виконавець (Я-А)</string>
     <string name="added_date">Дата додавання</string>
     <string name="credit_app">Простий музичний застосунок з використанням YouTube Music для бекенду \n\nSimpMusic - це проєкт з відкритим вихідним кодом для потокової передачі музики з YouTube та YouTube Music без реклами та відстеження. SimpMusic надає багато можливостей:\n\n - Потокова музика\n - Синхронізовані тексти\n - Персоналізація даних\n - тощо... \n\nSimpMusic завжди безкоштовний і без реклами\n\nСтворено з ❤️ від Tuan Minh Nguyen Duc (maxrave-dev)</string>
     <string name="issue_tracker">Відстежувач випусків</string>

--- a/composeApp/src/commonMain/composeResources/values-vi/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-vi/strings.xml
@@ -271,6 +271,12 @@
     <string name="sort">Sắp xếp</string>
     <string name="older_first">Cũ trước</string>
     <string name="newer_first">Mới trước</string>
+    <string name="download_sort_title_asc">Tên bài hát (A-Z)</string>
+    <string name="download_sort_title_desc">Tên bài hát (Z-A)</string>
+    <string name="download_sort_date_newest">Mới nhất trước</string>
+    <string name="download_sort_date_oldest">Cũ nhất trước</string>
+    <string name="download_sort_artist_asc">Nghệ sĩ (A-Z)</string>
+    <string name="download_sort_artist_desc">Nghệ sĩ (Z-A)</string>
     <string name="added_date">Ngày thêm vào</string>
     <string name="credit_app">Một ứng dụng âm nhạc đơn giản sử dụng dữ liệu từ YouTube Music \n\nSimpMusic là một dự án nguồn mở để phát nhạc từ YouTube và YouTube Music mà không bị quảng cáo và theo dõi. SimpMusic cung cấp nhiều tính năng:\n\n - Phát nhạc \n - Lời bài hát được đồng bộ hóa\n - Cá nhân hóa dữ liệu\n - v.v… \n\nSimpMusic luôn miễn phí và không có quảng cáo\n\nXây dựng với ❤️ bởi Nguyên Đức Tuấn Minh (maxrave-dev)</string>
     <string name="issue_tracker">Theo dõi lỗi</string>

--- a/composeApp/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -268,6 +268,12 @@
     <string name="sort">排序</string>
     <string name="older_first">由舊至新</string>
     <string name="newer_first">最新作品</string>
+    <string name="download_sort_title_asc">標題 (A-Z)</string>
+    <string name="download_sort_title_desc">標題 (Z-A)</string>
+    <string name="download_sort_date_newest">最新優先</string>
+    <string name="download_sort_date_oldest">最舊優先</string>
+    <string name="download_sort_artist_asc">藝人 (A-Z)</string>
+    <string name="download_sort_artist_desc">藝人 (Z-A)</string>
     <string name="added_date">已添加日期</string>
     <string name="credit_app">SimpMusic是一個開放原始碼、零廣告、使用YouTube Music作為後端的簡單音樂應用程式 \n\n用於從YouTube和YouTube Music串流音樂。SimpMusic提供許多功能：\n\n - 串流音樂\n - 同步歌詞\n - 個人化資料\n - 等等... \n\nSimpMusic總是免費，無廣告\n\n由Tuan Minh Nguyen Duc (maxrave) 開發 ❤️</string>
     <string name="issue_tracker">回報問題</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -270,6 +270,12 @@
     <string name="sort">排序方式</string>
     <string name="older_first">较早的优先</string>
     <string name="newer_first">较新的在前</string>
+    <string name="download_sort_title_asc">标题 (A-Z)</string>
+    <string name="download_sort_title_desc">标题 (Z-A)</string>
+    <string name="download_sort_date_newest">最新优先</string>
+    <string name="download_sort_date_oldest">最旧优先</string>
+    <string name="download_sort_artist_asc">艺术家 (A-Z)</string>
+    <string name="download_sort_artist_desc">艺术家 (Z-A)</string>
     <string name="added_date">已添加日期</string>
     <string name="credit_app">使用 YouTube Music 作为后端的简单音乐应用 \n\nSimpMusic 是一个开源项目，可以在没有广告和跟踪的情况下从 YouTube 和 YouTube Music 中流式播放音乐。SimpMusic 提供许多功能：\n\n - 流媒体音乐 \n - 同步歌词 \n - 个性化数据 \n -等等… \n\nSimpMusic始终是免费的，没有广告\n\n Tuan Minh Nguyen Duc(Maxrave-dev) 用 ❤️ 构建</string>
     <string name="issue_tracker">问题跟踪</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -273,6 +273,12 @@
     <string name="sort">Sort</string>
     <string name="older_first">Older First</string>
     <string name="newer_first">Newer First</string>
+    <string name="download_sort_title_asc">Title (A-Z)</string>
+    <string name="download_sort_title_desc">Title (Z-A)</string>
+    <string name="download_sort_date_newest">Newest first</string>
+    <string name="download_sort_date_oldest">Oldest first</string>
+    <string name="download_sort_artist_asc">Artist (A-Z)</string>
+    <string name="download_sort_artist_desc">Artist (Z-A)</string>
     <string name="added_date">Added date</string>
     <string name="credit_app">A simple music app using YouTube Music for backend \n\nSimpMusic is an open source project to stream music from YouTube and YouTube Music without ads and tracking. SimpMusic provides many features:\n\n - Streaming music \n - Synced lyrics\n - Personalize data\n - etc… \n\nSimpMusic is always free and no ads\n\nBuild with ❤️ from Tuan Minh Nguyen Duc (maxrave-dev)</string>
     <string name="issue_tracker">Issue Tracker</string>

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/extension/AllExt.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/extension/AllExt.kt
@@ -6,6 +6,7 @@ import com.maxrave.domain.data.model.browse.artist.ArtistBrowse
 import com.maxrave.domain.extension.now
 import com.maxrave.domain.utils.FilterState
 import com.maxrave.domain.utils.toTrack
+import com.maxrave.simpmusic.ui.screen.library.DownloadSortType
 import com.maxrave.simpmusic.viewModel.ArtistScreenData
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
@@ -223,6 +224,16 @@ fun FilterState.displayNameRes(): StringResource =
         FilterState.OlderFirst -> Res.string.older_first
         FilterState.Title -> Res.string.title
         FilterState.CustomOrder -> Res.string.custom_order
+    }
+
+fun DownloadSortType.displayNameRes(): StringResource =
+    when (this) {
+        DownloadSortType.TitleAsc -> Res.string.download_sort_title_asc
+        DownloadSortType.TitleDesc -> Res.string.download_sort_title_desc
+        DownloadSortType.DateNewest -> Res.string.download_sort_date_newest
+        DownloadSortType.DateOldest -> Res.string.download_sort_date_oldest
+        DownloadSortType.ArtistAsc -> Res.string.download_sort_artist_asc
+        DownloadSortType.ArtistDesc -> Res.string.download_sort_artist_desc
     }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
@@ -133,6 +133,7 @@ import com.maxrave.simpmusic.extension.displayNameRes
 import com.maxrave.simpmusic.extension.greyScale
 import com.maxrave.simpmusic.ui.navigation.destination.list.AlbumDestination
 import com.maxrave.simpmusic.ui.navigation.destination.list.ArtistDestination
+import com.maxrave.simpmusic.ui.screen.library.DownloadSortType
 import com.maxrave.simpmusic.ui.theme.seed
 import com.maxrave.simpmusic.ui.theme.typo
 import com.maxrave.simpmusic.ui.theme.white
@@ -3173,4 +3174,100 @@ sealed class DevLogInType {
             is YouTube -> getString(Res.string.your_youtube_cookie)
             is Discord -> getString(Res.string.your_discord_token)
         }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SortDownloadsBottomSheet(
+    selectedState: DownloadSortType,
+    onDismiss: () -> Unit,
+    onSortChanged: (DownloadSortType) -> Unit,
+) {
+    val modelBottomSheetState =
+        rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    val sortOptions =
+        remember {
+            DownloadSortType.entries
+        }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = modelBottomSheetState,
+        containerColor = Color.Transparent,
+        contentColor = Color.Transparent,
+        dragHandle = null,
+        scrimColor = Color.Black.copy(alpha = .5f),
+        contentWindowInsets = { WindowInsets(0, 0, 0, 0) },
+    ) {
+        Card(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight(),
+            shape = RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp),
+            colors = CardDefaults.cardColors().copy(containerColor = Color(0xFF242424)),
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Spacer(modifier = Modifier.height(5.dp))
+                Card(
+                    modifier =
+                        Modifier
+                            .width(60.dp)
+                            .height(4.dp),
+                    colors =
+                        CardDefaults.cardColors().copy(
+                            containerColor = Color(0xFF474545),
+                        ),
+                    shape = RoundedCornerShape(50),
+                ) {}
+                Text(
+                    stringResource(Res.string.sort_by),
+                    style = typo().labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier =
+                        Modifier
+                            .padding(start = 16.dp, top = 16.dp, bottom = 24.dp)
+                            .align(Alignment.Start),
+                )
+                LazyColumn(
+                    contentPadding = PaddingValues(horizontal = 16.dp),
+                ) {
+                    items(sortOptions, key = { sortOption -> sortOption.hashCode() }) { sortOption ->
+                        val isSelected = sortOption == selectedState
+                        Row(
+                            Modifier
+                                .padding(vertical = 4.dp)
+                                .clickable {
+                                    onSortChanged(sortOption)
+                                    onDismiss()
+                                }.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = stringResource(sortOption.displayNameRes()),
+                                style = typo().labelMedium,
+                                fontWeight = FontWeight.Medium,
+                                color = if (isSelected) seed else Color.White,
+                            )
+                            Spacer(modifier = Modifier.weight(1f))
+                            if (isSelected) {
+                                Image(
+                                    painter = painterResource(Res.drawable.done),
+                                    contentDescription = "Selected",
+                                    colorFilter = ColorFilter.tint(seed),
+                                    modifier = Modifier.size(32.dp),
+                                )
+                            } else {
+                                Spacer(modifier = Modifier.size(32.dp))
+                            }
+                        }
+                    }
+                }
+                EndOfModalBottomSheet()
+            }
+        }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/library/DownloadSortType.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/library/DownloadSortType.kt
@@ -1,0 +1,55 @@
+package com.maxrave.simpmusic.ui.screen.library
+
+/**
+ * Sort types for the Downloaded songs screen.
+ * Each variant represents a sort criterion + direction.
+ * Persistence is handled via [toKey]/[fromKey] serialization.
+ */
+sealed class DownloadSortType {
+    data object TitleAsc : DownloadSortType()
+    data object TitleDesc : DownloadSortType()
+    data object DateNewest : DownloadSortType()
+    data object DateOldest : DownloadSortType()
+    data object ArtistAsc : DownloadSortType()
+    data object ArtistDesc : DownloadSortType()
+
+    fun toKey(): String =
+        when (this) {
+            TitleAsc -> KEY_TITLE_ASC
+            TitleDesc -> KEY_TITLE_DESC
+            DateNewest -> KEY_DATE_NEWEST
+            DateOldest -> KEY_DATE_OLDEST
+            ArtistAsc -> KEY_ARTIST_ASC
+            ArtistDesc -> KEY_ARTIST_DESC
+        }
+
+    companion object {
+        private const val KEY_TITLE_ASC = "title_asc"
+        private const val KEY_TITLE_DESC = "title_desc"
+        private const val KEY_DATE_NEWEST = "date_newest"
+        private const val KEY_DATE_OLDEST = "date_oldest"
+        private const val KEY_ARTIST_ASC = "artist_asc"
+        private const val KEY_ARTIST_DESC = "artist_desc"
+
+        /** Preference key used with DataStoreManager */
+        const val PREFERENCE_KEY = "download_sort_type"
+
+        /** Default sort when no preference is stored */
+        val DEFAULT = DateNewest
+
+        fun fromKey(key: String?): DownloadSortType =
+            when (key) {
+                KEY_TITLE_ASC -> TitleAsc
+                KEY_TITLE_DESC -> TitleDesc
+                KEY_DATE_NEWEST -> DateNewest
+                KEY_DATE_OLDEST -> DateOldest
+                KEY_ARTIST_ASC -> ArtistAsc
+                KEY_ARTIST_DESC -> ArtistDesc
+                else -> DEFAULT
+            }
+
+        /** All available sort options, in display order */
+        val entries: List<DownloadSortType> =
+            listOf(DateNewest, DateOldest, TitleAsc, TitleDesc, ArtistAsc, ArtistDesc)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/library/LibraryDynamicPlaylistScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/library/LibraryDynamicPlaylistScreen.kt
@@ -54,6 +54,7 @@ import com.maxrave.simpmusic.ui.component.NowPlayingBottomSheet
 import com.maxrave.simpmusic.ui.component.PlaylistFullWidthItems
 import com.maxrave.simpmusic.ui.component.RippleIconButton
 import com.maxrave.simpmusic.ui.component.SongFullWidthItems
+import com.maxrave.simpmusic.ui.component.SortDownloadsBottomSheet
 import com.maxrave.simpmusic.ui.navigation.destination.list.AlbumDestination
 import com.maxrave.simpmusic.ui.navigation.destination.list.ArtistDestination
 import com.maxrave.simpmusic.ui.theme.typo
@@ -73,6 +74,7 @@ import simpmusic.composeapp.generated.resources.Res
 import simpmusic.composeapp.generated.resources.baseline_arrow_back_ios_new_24
 import simpmusic.composeapp.generated.resources.baseline_close_24
 import simpmusic.composeapp.generated.resources.baseline_search_24
+import simpmusic.composeapp.generated.resources.baseline_sort_24
 import simpmusic.composeapp.generated.resources.downloaded
 import simpmusic.composeapp.generated.resources.favorite
 import simpmusic.composeapp.generated.resources.followed
@@ -100,7 +102,10 @@ fun LibraryDynamicPlaylistScreen(
     var chosenSong: SongEntity? by remember { mutableStateOf(null) }
     var showBottomSheet by rememberSaveable { mutableStateOf(false) }
     var showSearchBar by rememberSaveable { mutableStateOf(false) }
+    var sortBottomSheetShow by rememberSaveable { mutableStateOf(false) }
     var query by rememberSaveable { mutableStateOf("") }
+
+    val downloadSortType by viewModel.downloadSortType.collectAsStateWithLifecycle()
 
     val favorite by viewModel.listFavoriteSong.collectAsStateWithLifecycle()
     var tempFavorite by rememberSaveable { mutableStateOf(emptyList<SongEntity>()) }
@@ -378,6 +383,16 @@ fun LibraryDynamicPlaylistScreen(
             song = chosenSong ?: return,
         )
     }
+    if (sortBottomSheetShow) {
+        SortDownloadsBottomSheet(
+            selectedState = downloadSortType,
+            onDismiss = { sortBottomSheetShow = false },
+            onSortChanged = {
+                viewModel.setDownloadSort(it)
+                sortBottomSheetShow = false
+            },
+        )
+    }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
@@ -405,6 +420,18 @@ fun LibraryDynamicPlaylistScreen(
                 }
             },
             actions = {
+                if (LibraryDynamicPlaylistType.toType(type) == LibraryDynamicPlaylistType.Downloaded) {
+                    Box(Modifier.padding(horizontal = 5.dp)) {
+                        RippleIconButton(
+                            Res.drawable.baseline_sort_24,
+                            Modifier
+                                .size(32.dp),
+                            true,
+                        ) {
+                            sortBottomSheetShow = true
+                        }
+                    }
+                }
                 Box(Modifier.padding(horizontal = 5.dp)) {
                     RippleIconButton(
                         if (showSearchBar) Res.drawable.baseline_close_24 else Res.drawable.baseline_search_24,

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/LibraryDynamicPlaylistViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/LibraryDynamicPlaylistViewModel.kt
@@ -4,18 +4,23 @@ import androidx.lifecycle.viewModelScope
 import com.maxrave.common.Config
 import com.maxrave.domain.data.entities.ArtistEntity
 import com.maxrave.domain.data.entities.SongEntity
+import com.maxrave.domain.manager.DataStoreManager
 import com.maxrave.domain.mediaservice.handler.PlaylistType
 import com.maxrave.domain.mediaservice.handler.QueueData
 import com.maxrave.domain.repository.ArtistRepository
 import com.maxrave.domain.repository.SongRepository
 import com.maxrave.domain.utils.toArrayListTrack
 import com.maxrave.domain.utils.toTrack
+import com.maxrave.simpmusic.ui.screen.library.DownloadSortType
 import com.maxrave.simpmusic.ui.screen.library.LibraryDynamicPlaylistType
 import com.maxrave.simpmusic.viewModel.base.BaseViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import org.koin.core.component.inject
 import simpmusic.composeapp.generated.resources.Res
 import simpmusic.composeapp.generated.resources.playlist
 
@@ -23,6 +28,8 @@ class LibraryDynamicPlaylistViewModel(
     private val songRepository: SongRepository,
     private val artistRepository: ArtistRepository,
 ) : BaseViewModel() {
+    private val dataStoreManager: DataStoreManager by inject()
+
     private val _listFavoriteSong: MutableStateFlow<List<SongEntity>> = MutableStateFlow(emptyList())
     val listFavoriteSong: StateFlow<List<SongEntity>> get() = _listFavoriteSong
 
@@ -32,6 +39,14 @@ class LibraryDynamicPlaylistViewModel(
     private val _listMostPlayedSong: MutableStateFlow<List<SongEntity>> = MutableStateFlow(emptyList())
     val listMostPlayedSong: StateFlow<List<SongEntity>> get() = _listMostPlayedSong
 
+    // Raw downloaded songs from repository (unsorted)
+    private val _rawDownloadedSongs: MutableStateFlow<List<SongEntity>> = MutableStateFlow(emptyList())
+
+    // Current download sort preference
+    private val _downloadSortType: MutableStateFlow<DownloadSortType> = MutableStateFlow(DownloadSortType.DEFAULT)
+    val downloadSortType: StateFlow<DownloadSortType> get() = _downloadSortType
+
+    // Sorted downloaded songs (combines raw data + sort type)
     private val _listDownloadedSong: MutableStateFlow<List<SongEntity>> = MutableStateFlow(emptyList())
     val listDownloadedSong: StateFlow<List<SongEntity>> get() = _listDownloadedSong
 
@@ -39,7 +54,23 @@ class LibraryDynamicPlaylistViewModel(
         getFavoriteSong()
         getFollowedArtist()
         getMostPlayedSong()
+        loadDownloadSortPreference()
         getDownloadedSong()
+        observeSortedDownloads()
+    }
+
+    private fun loadDownloadSortPreference() {
+        viewModelScope.launch {
+            val savedKey = dataStoreManager.getString(DownloadSortType.PREFERENCE_KEY).first()
+            _downloadSortType.value = DownloadSortType.fromKey(savedKey)
+        }
+    }
+
+    fun setDownloadSort(sortType: DownloadSortType) {
+        _downloadSortType.value = sortType
+        viewModelScope.launch {
+            dataStoreManager.putString(DownloadSortType.PREFERENCE_KEY, sortType.toKey())
+        }
     }
 
     private fun getFavoriteSong() {
@@ -75,13 +106,37 @@ class LibraryDynamicPlaylistViewModel(
     private fun getDownloadedSong() {
         viewModelScope.launch {
             songRepository.getDownloadedSongs().collectLatest { downloadedSong ->
-                _listDownloadedSong.value =
-                    (downloadedSong ?: emptyList()).sortedByDescending {
-                        it.downloadedAt ?: it.inLibrary
-                    }
+                _rawDownloadedSongs.value = downloadedSong ?: emptyList()
             }
         }
     }
+
+    /**
+     * Observes both the raw downloaded songs list and the current sort type,
+     * automatically re-sorting whenever either changes.
+     */
+    private fun observeSortedDownloads() {
+        viewModelScope.launch {
+            combine(_rawDownloadedSongs, _downloadSortType) { songs, sortType ->
+                applySorting(songs, sortType)
+            }.collectLatest { sorted ->
+                _listDownloadedSong.value = sorted
+            }
+        }
+    }
+
+    private fun applySorting(
+        songs: List<SongEntity>,
+        sortType: DownloadSortType,
+    ): List<SongEntity> =
+        when (sortType) {
+            DownloadSortType.TitleAsc -> songs.sortedBy { it.title.lowercase() }
+            DownloadSortType.TitleDesc -> songs.sortedByDescending { it.title.lowercase() }
+            DownloadSortType.DateNewest -> songs.sortedByDescending { it.downloadedAt ?: it.inLibrary }
+            DownloadSortType.DateOldest -> songs.sortedBy { it.downloadedAt ?: it.inLibrary }
+            DownloadSortType.ArtistAsc -> songs.sortedBy { it.artistName?.firstOrNull()?.lowercase() ?: "" }
+            DownloadSortType.ArtistDesc -> songs.sortedByDescending { it.artistName?.firstOrNull()?.lowercase() ?: "" }
+        }
 
     fun playSong(
         videoId: String,

--- a/composeApp/src/commonTest/kotlin/com/maxrave/simpmusic/ui/screen/library/DownloadSortTypeTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/maxrave/simpmusic/ui/screen/library/DownloadSortTypeTest.kt
@@ -1,0 +1,178 @@
+package com.maxrave.simpmusic.ui.screen.library
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
+
+/**
+ * Unit tests for [DownloadSortType] sealed class.
+ *
+ * Covers:
+ * - Serialization round-trip (toKey ↔ fromKey)
+ * - Default/fallback behavior
+ * - Entries list completeness
+ * - Equality semantics
+ */
+class DownloadSortTypeTest {
+
+    // ─── toKey / fromKey round-trip ─────────────────────────────────
+
+    @Test
+    fun titleAsc_roundTrip() {
+        val key = DownloadSortType.TitleAsc.toKey()
+        assertEquals("title_asc", key)
+        assertEquals(DownloadSortType.TitleAsc, DownloadSortType.fromKey(key))
+    }
+
+    @Test
+    fun titleDesc_roundTrip() {
+        val key = DownloadSortType.TitleDesc.toKey()
+        assertEquals("title_desc", key)
+        assertEquals(DownloadSortType.TitleDesc, DownloadSortType.fromKey(key))
+    }
+
+    @Test
+    fun dateNewest_roundTrip() {
+        val key = DownloadSortType.DateNewest.toKey()
+        assertEquals("date_newest", key)
+        assertEquals(DownloadSortType.DateNewest, DownloadSortType.fromKey(key))
+    }
+
+    @Test
+    fun dateOldest_roundTrip() {
+        val key = DownloadSortType.DateOldest.toKey()
+        assertEquals("date_oldest", key)
+        assertEquals(DownloadSortType.DateOldest, DownloadSortType.fromKey(key))
+    }
+
+    @Test
+    fun artistAsc_roundTrip() {
+        val key = DownloadSortType.ArtistAsc.toKey()
+        assertEquals("artist_asc", key)
+        assertEquals(DownloadSortType.ArtistAsc, DownloadSortType.fromKey(key))
+    }
+
+    @Test
+    fun artistDesc_roundTrip() {
+        val key = DownloadSortType.ArtistDesc.toKey()
+        assertEquals("artist_desc", key)
+        assertEquals(DownloadSortType.ArtistDesc, DownloadSortType.fromKey(key))
+    }
+
+    // ─── All variants round-trip (parameterized-style) ──────────────
+
+    @Test
+    fun allVariants_roundTrip() {
+        DownloadSortType.entries.forEach { sortType ->
+            val key = sortType.toKey()
+            val restored = DownloadSortType.fromKey(key)
+            assertEquals(
+                sortType,
+                restored,
+                "Round-trip failed for $sortType (key=$key)",
+            )
+        }
+    }
+
+    // ─── fromKey defaults / fallbacks ───────────────────────────────
+
+    @Test
+    fun fromKey_null_returnsDefault() {
+        val result = DownloadSortType.fromKey(null)
+        assertEquals(DownloadSortType.DEFAULT, result)
+        assertIs<DownloadSortType.DateNewest>(result)
+    }
+
+    @Test
+    fun fromKey_emptyString_returnsDefault() {
+        assertEquals(DownloadSortType.DEFAULT, DownloadSortType.fromKey(""))
+    }
+
+    @Test
+    fun fromKey_unknownKey_returnsDefault() {
+        assertEquals(DownloadSortType.DEFAULT, DownloadSortType.fromKey("unknown_sort"))
+    }
+
+    @Test
+    fun fromKey_caseSensitive_unknownReturnsDefault() {
+        // Keys should be exact match, not case-insensitive
+        assertEquals(DownloadSortType.DEFAULT, DownloadSortType.fromKey("Title_Asc"))
+        assertEquals(DownloadSortType.DEFAULT, DownloadSortType.fromKey("TITLE_ASC"))
+    }
+
+    // ─── DEFAULT constant ───────────────────────────────────────────
+
+    @Test
+    fun default_isDateNewest() {
+        assertIs<DownloadSortType.DateNewest>(DownloadSortType.DEFAULT)
+    }
+
+    // ─── entries list ───────────────────────────────────────────────
+
+    @Test
+    fun entries_containsAllSixVariants() {
+        assertEquals(6, DownloadSortType.entries.size)
+    }
+
+    @Test
+    fun entries_containsEachVariant() {
+        val entries = DownloadSortType.entries
+        assertIs<DownloadSortType.DateNewest>(entries[0])
+        assertIs<DownloadSortType.DateOldest>(entries[1])
+        assertIs<DownloadSortType.TitleAsc>(entries[2])
+        assertIs<DownloadSortType.TitleDesc>(entries[3])
+        assertIs<DownloadSortType.ArtistAsc>(entries[4])
+        assertIs<DownloadSortType.ArtistDesc>(entries[5])
+    }
+
+    @Test
+    fun entries_hasNoDuplicates() {
+        val entries = DownloadSortType.entries
+        assertEquals(entries.size, entries.toSet().size)
+    }
+
+    // ─── toKey uniqueness ───────────────────────────────────────────
+
+    @Test
+    fun allKeys_areUnique() {
+        val keys = DownloadSortType.entries.map { it.toKey() }
+        assertEquals(keys.size, keys.toSet().size, "Duplicate keys found: $keys")
+    }
+
+    @Test
+    fun allKeys_areNonEmpty() {
+        DownloadSortType.entries.forEach { sortType ->
+            val key = sortType.toKey()
+            assertNotEquals("", key, "Key for $sortType should not be empty")
+        }
+    }
+
+    // ─── PREFERENCE_KEY ─────────────────────────────────────────────
+
+    @Test
+    fun preferenceKey_isNonEmpty() {
+        assertNotEquals("", DownloadSortType.PREFERENCE_KEY)
+    }
+
+    @Test
+    fun preferenceKey_expectedValue() {
+        assertEquals("download_sort_type", DownloadSortType.PREFERENCE_KEY)
+    }
+
+    // ─── Equality ───────────────────────────────────────────────────
+
+    @Test
+    fun sameVariants_areEqual() {
+        assertEquals(DownloadSortType.TitleAsc, DownloadSortType.TitleAsc)
+        assertEquals(DownloadSortType.ArtistDesc, DownloadSortType.ArtistDesc)
+    }
+
+    @Test
+    fun differentVariants_areNotEqual() {
+        assertNotEquals<DownloadSortType>(DownloadSortType.TitleAsc, DownloadSortType.TitleDesc)
+        assertNotEquals<DownloadSortType>(DownloadSortType.DateNewest, DownloadSortType.DateOldest)
+        assertNotEquals<DownloadSortType>(DownloadSortType.ArtistAsc, DownloadSortType.ArtistDesc)
+        assertNotEquals<DownloadSortType>(DownloadSortType.TitleAsc, DownloadSortType.ArtistAsc)
+    }
+}


### PR DESCRIPTION
## Summary

Add the ability to sort downloaded songs by multiple criteria with ascending/descending direction. The sort preference persists between sessions.

## Sort Options

| Option | Description |
|--------|-------------|
| Newest first | Download date, most recent first (default — current behavior) |
| Oldest first | Download date, oldest first |
| Title (A-Z) | Alphabetical by song title |
| Title (Z-A) | Reverse alphabetical by song title |
| Artist (A-Z) | Alphabetical by artist name |
| Artist (Z-A) | Reverse alphabetical by artist name |

## Implementation Details

### Architecture
- **No changes to `core` submodule** — all new code lives in `composeApp`
- Follows the same MVVM + StateFlow + Compose patterns used throughout the app
- Reuses the visual style of `SortPlaylistBottomSheet` from `LocalPlaylistScreen`

### New Files
- `DownloadSortType.kt` — Sealed class with 6 sort variants + serialization (`toKey()`/`fromKey()`)

### Modified Files
- **`LibraryDynamicPlaylistViewModel.kt`** — Reactive sorting via `combine(rawSongs, sortType)`, preference persistence via `DataStoreManager.putString()/getString()`
- **`LibraryDynamicPlaylistScreen.kt`** — Sort icon button in TopAppBar (visible only for Downloaded type), `SortDownloadsBottomSheet` integration
- **`ModalBottomSheet.kt`** — New `SortDownloadsBottomSheet` composable
- **`AllExt.kt`** — `DownloadSortType.displayNameRes()` extension function
- **26 `strings.xml` files** — i18n support for all existing locales (ar, az, bg, ca, de, es, fa, fi, fr, hi, in, it, iw, ja, ko, nl, pl, pt, ru, th, tr, uk, vi, zh, zh-rTW)

### Key Design Decisions
- `DownloadSortType` is separate from `FilterState` (avoids modifying `core` submodule)
- `DataStoreManager` injected via `by inject()` from `KoinComponent` (no DI module changes needed)
- Client-side sorting (in-memory) — appropriate for typical download list sizes
- Sort preference key: `"download_sort_type"`

## Screenshots
_Sort icon appears in the Downloads screen TopAppBar. Tapping opens a bottom sheet with 6 sort options._

## Testing Checklist
- [ ] Navigate to Library → Downloaded → sort icon is visible
- [ ] Each sort option reorders the list correctly
- [ ] Sort preference persists after leaving and returning to the screen
- [ ] Search works correctly with any active sort order
- [ ] Empty download list doesn't crash
- [ ] Songs without artist name sort correctly (fallback to empty string)