### PR TITLE
Refine media notification visibility to pause-only states

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -173,7 +173,7 @@
                 android:value="true" />
         </service>
         <service
-            android:name="com.maxrave.media3.service.SimpleMediaService"
+            android:name=".service.SimpMusicMediaService"
             android:exported="true"
             android:foregroundServiceType="mediaPlayback"
             android:stopWithTask="false"

--- a/androidApp/src/main/java/com/maxrave/simpmusic/service/SimpMusicMediaService.kt
+++ b/androidApp/src/main/java/com/maxrave/simpmusic/service/SimpMusicMediaService.kt
@@ -1,0 +1,27 @@
+package com.maxrave.simpmusic.service
+
+import androidx.media3.common.Player
+import androidx.media3.session.MediaSession
+import com.maxrave.media3.service.SimpleMediaService
+
+/**
+ * Keep media controls visible while paused by continuing to request notification updates
+ * whenever there is an active queue item.
+ */
+class SimpMusicMediaService : SimpleMediaService() {
+    override fun onUpdateNotification(
+        session: MediaSession,
+        startInForegroundRequired: Boolean,
+    ) {
+        val player = session.player
+        val shouldKeepVisibleWhenPaused =
+            player.currentMediaItem != null &&
+                player.playbackState != Player.STATE_IDLE &&
+                player.playbackState != Player.STATE_ENDED
+
+        super.onUpdateNotification(
+            session,
+            startInForegroundRequired = startInForegroundRequired || shouldKeepVisibleWhenPaused,
+        )
+    }
+}


### PR DESCRIPTION
Refined SimpMusicMediaService notification logic so it keeps media controls visible for paused content with an active media item, but no longer forces this behavior for terminal playback states (STATE_IDLE, STATE_ENDED). This narrows behavior to the intended HyperIsland pause scenario and reduces side effects. 

Kept the existing service override structure and notification delegation path, while making the foreground-eligibility condition state-aware.