### PR TITLE
fix(widget): stop unloading viewModelModule in onDestroy – fixes ANDROID-1FM

### DIFF
--- a/androidApp/src/main/java/com/maxrave/simpmusic/MainActivity.kt
+++ b/androidApp/src/main/java/com/maxrave/simpmusic/MainActivity.kt
@@ -225,7 +225,11 @@ class MainActivity : AppCompatActivity() {
         if (shouldStopMusicService && shouldUnbind && isFinishing) {
             viewModel.isServiceRunning = false
         }
-        unloadKoinModules(viewModelModule)
+        // Do NOT unload viewModelModule here. The app widget (MainAppWidget) injects
+        // SharedViewModel via KoinComponent.inject(); unloading the module on every
+        // activity destruction caused NoDefinitionFoundException in the widget process
+        // (ANDROID-1FM). The module is re-created in onCreate() anyway, so there is no
+        // benefit to unloading it here.
         super.onDestroy()
         Logger.d("MainActivity", "onDestroy: ")
     }


### PR DESCRIPTION
## Summary

- `MainAppWidget` uses `KoinComponent.inject<SharedViewModel>()` (lazy delegate)
- `MainActivity.onDestroy()` called `unloadKoinModules(viewModelModule)`, removing `SharedViewModel` from Koin
- Any subsequent widget update (launcher refresh, periodic update) after activity destruction failed with `NoDefinitionFoundException`
- Fix: removed the `unloadKoinModules` call from `onDestroy`. The `onCreate` still does `unload + reload` to force-recreate `SharedViewModel`, so there is no regression

## Sentry issue fixed
- **ANDROID-1FM**: `NoDefinitionFoundException: No definition found for type 'SharedViewModel'` — 1,538 users, 8,510 events

## Root cause trace
```
MainAppWidget.provideGlance()
  → sharedViewModel (lazy resolves for first time)
  → KoinComponent.inject<SharedViewModel>()
  → Koin looks up SharedViewModel in viewModelModule
  → viewModelModule was unloaded in onDestroy() → NoDefinitionFoundException
```

## Test plan
- [ ] Add SimpMusic widget to home screen
- [ ] Launch app, then swipe app away (triggers `onDestroy`)  
- [ ] Widget should still display; no crash in logcat
- [ ] Re-launch app — player state should reconnect normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)