### PR TITLE
fix(ui): pass release body as 3rd format arg to fix ANDROID-2D0 + ANDROID-2QY

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/App.kt
@@ -626,6 +626,7 @@ fun App(viewModel: SharedViewModel = koinInject()) {
                                         Res.string.update_message,
                                         response.tagName,
                                         formatted,
+                                        response.body ?: "",
                                     )
                                 }
                             Column(


### PR DESCRIPTION
## Summary

- Indonesian (`values-in`) and Hebrew (`values-iw`) translations of `update_message` include a `%3\$s` placeholder for the release changelog body
- The call site only passed 2 args: `(tagName, formattedDate)` — missing the 3rd
- When users in `in_ID` or `iw_IL` locale viewed the update dialog, the format engine tried to access `args[2]` from a 2-element list → crash

## Sentry issues fixed
- **ANDROID-2D0**: `IndexOutOfBoundsException: Index: 2, Size: 2` — 1,075 users, 6,695 events
- **ANDROID-2QY**: `IndexOutOfBoundsException: Index 2 out of bounds for length 2` — 930 users, 6,186 events

## Root cause
```
getString(Res.string.update_message, tagName, formattedDate)
          ↑ values-in: "Versi %1$s tersedia\nRilis: %2$s\nLog diubah:\n%3$s"
                                                                         ↑ args[2] → crash
```

## Fix
Pass `response.body ?: ""` as the 3rd argument. Locales that do not use `%3$s` silently ignore it; locales that do (Indonesian, Hebrew) now correctly render the changelog in the dialog.

## Test plan
- [ ] Change device locale to Indonesian (`in_ID`) or Hebrew (`iw`)
- [ ] Trigger the update dialog (or mock a version response)
- [ ] Verify no crash and the dialog shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)