### PR TITLE
Fix: Add high refresh rate (90Hz/120Hz) optimization support (#2086)

### DIFF
--- a/androidApp/src/main/java/com/maxrave/simpmusic/MainActivity.kt
+++ b/androidApp/src/main/java/com/maxrave/simpmusic/MainActivity.kt
@@ -221,6 +221,17 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val display = windowManager.defaultDisplay
+            val modes = display.supportedModes
+            val maxRefreshRateMode = modes.maxByOrNull { it.refreshRate }
+            if (maxRefreshRateMode != null) {
+                val layoutParams = window.attributes
+                layoutParams.preferredDisplayModeId = maxRefreshRateMode.modeId
+                window.attributes = layoutParams
+            }
+        }
+
         viewModel.getLocation()
 
         setContent {


### PR DESCRIPTION
Fixes #2086

Description of the Bug:
Users with high refresh rate screens (90Hz, 120Hz, etc.) experience UI scrolling locked to 60Hz. This happens because many Android OEM skins (like MIUI, OneUI, and ColorOS) aggressively throttle refresh rates for standard apps to preserve battery, especially in Compose-heavy applications, unless the activity explicitly requests the higher rate.

Resolution:

Added a hardware display check in MainActivity.kt (for Android M and above).

The app now dynamically queries the device's supportedModes, finds the mode with the highest available refresh rate, and assigns it to window.attributes.preferredDisplayModeId.

This forces the OS to uncap the framerate, allowing for buttery-smooth scrolling and animations across the entire application without any negative impact on standard 60Hz devices.