### PR TITLE
feat: Save current playback queue as a playlist (#2092)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -920,6 +921,7 @@ fun QueueBottomSheet(
         }
     var overscrollJob by remember { mutableStateOf<Job?>(null) }
     var shouldShowQueueItemBottomSheet by rememberSaveable { mutableStateOf(false) }
+    var shouldShowAddToPlaylist by rememberSaveable { mutableStateOf(false) }
     var clickMoreIndex by rememberSaveable { mutableIntStateOf(0) }
     val screenDataState by sharedViewModel.nowPlayingScreenData.collectAsStateWithLifecycle()
     val songEntity by sharedViewModel.nowPlayingState.map { it?.songEntity }.collectAsState(null)
@@ -980,6 +982,30 @@ fun QueueBottomSheet(
             onDismiss = { shouldShowQueueItemBottomSheet = false },
             index = clickMoreIndex,
             musicServiceHandler = musicServiceHandler,
+        )
+    }
+
+    if (shouldShowAddToPlaylist) {
+        val viewModel: NowPlayingBottomSheetViewModel = koinViewModel()
+        val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+        LaunchedEffect(Unit) {
+            viewModel.resetPlaylists()
+        }
+
+        AddToPlaylistModalBottomSheet(
+            isBottomSheetVisible = true,
+            listLocalPlaylist = uiState.listLocalPlaylist,
+            listYouTubePlaylist = uiState.listYouTubePlaylist,
+            onDismiss = { shouldShowAddToPlaylist = false },
+            onClick = { playlist ->
+                sharedViewModel.saveQueueToLocalPlaylist(playlist.id, queue)
+                shouldShowAddToPlaylist = false
+            },
+            onYTPlaylistClick = { playlist ->
+                sharedViewModel.saveQueueToYouTubePlaylist(playlist.browseId, queue)
+                shouldShowAddToPlaylist = false
+            }
         )
     }
 
@@ -1087,11 +1113,18 @@ fun QueueBottomSheet(
                     Text(
                         text = stringResource(Res.string.queue),
                         style = typo().titleMedium,
-                        modifier =
-                            Modifier
-                                .padding(horizontal = 20.dp)
-                                .weight(1f),
+                        modifier = Modifier.padding(start = 20.dp),
                     )
+                    IconButton(
+                        onClick = { shouldShowAddToPlaylist = true },
+                        modifier = Modifier.weight(1f).wrapContentWidth(Alignment.Start)
+                    ) {
+                        Icon(
+                            painter = painterResource(Res.drawable.baseline_playlist_add_24),
+                            contentDescription = "Save as Playlist",
+                            tint = Color.White
+                        )
+                    }
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
                             text = stringResource(Res.string.endless_queue),

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/SharedViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/SharedViewModel.kt
@@ -81,6 +81,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.lastOrNull
@@ -92,6 +93,8 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import simpmusic.composeapp.generated.resources.Res
 import simpmusic.composeapp.generated.resources.added_to_queue
+import simpmusic.composeapp.generated.resources.added_to_playlist
+import simpmusic.composeapp.generated.resources.added_to_youtube_playlist
 import simpmusic.composeapp.generated.resources.added_to_youtube_liked
 import simpmusic.composeapp.generated.resources.error
 import simpmusic.composeapp.generated.resources.play_next
@@ -1646,6 +1649,37 @@ class SharedViewModel(
 
     fun activityRecreate() {
         _recreateActivity.value = true
+    }
+
+    fun saveQueueToLocalPlaylist(playlistId: Long, tracks: List<Track>) {
+        viewModelScope.launch(Dispatchers.IO) {
+            tracks.forEach { track ->
+                localPlaylistRepository.addTrackToLocalPlaylist(
+                    id = playlistId,
+                    song = track.toSongEntity(),
+                    successMessage = getString(Res.string.added_to_playlist),
+                    updatedYtMessage = getString(Res.string.added_to_youtube_playlist),
+                    errorMessage = getString(Res.string.error)
+                ).collect {}
+            }
+            withContext(Dispatchers.Main) {
+                makeToast(getString(Res.string.added_to_playlist))
+            }
+        }
+    }
+
+    fun saveQueueToYouTubePlaylist(browseId: String, tracks: List<Track>) {
+        viewModelScope.launch(Dispatchers.IO) {
+            tracks.forEach { track ->
+                localPlaylistRepository.addYouTubePlaylistItem(
+                    youtubePlaylistId = browseId,
+                    videoId = track.videoId
+                ).collect {}
+            }
+            withContext(Dispatchers.Main) {
+                makeToast(getString(Res.string.added_to_youtube_playlist))
+            }
+        }
     }
 
     fun activityRecreateDone() {


### PR DESCRIPTION
Resolves #2092.

Description:
This PR introduces the ability to save the current playback queue directly to a new or existing playlist, eliminating the need for users to manually add songs one by one when discovering new tracks through radio or autoplay.

Changes Included:

UI: Added a "Save as Playlist" icon button to the top left of the QueueBottomSheet.

Flow: Tapping the button opens the existing AddToPlaylistModalBottomSheet, allowing the user to select an existing Local/YouTube playlist or create a brand new one.

Logic: Implemented saveQueueToLocalPlaylist and saveQueueToYouTubePlaylist in SharedViewModel to safely handle batch-saving the queue tracks on a background thread while preventing UI thread crashes.

Testing:

Verified successful batch saving to local playlists.

Verified successful batch saving to YouTube playlists.

Ensured Toast notifications safely execute on the Main UI thread without throwing NullPointerException.