### PR TITLE
Fix: Enable high refresh rate support via preferredRefreshRate (#2086)

### DIFF
--- a/androidApp/src/main/java/com/maxrave/simpmusic/MainActivity.kt
+++ b/androidApp/src/main/java/com/maxrave/simpmusic/MainActivity.kt
@@ -221,6 +221,17 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val display = windowManager.defaultDisplay
+            val modes = display.supportedModes
+            val maxRefreshRateMode = modes.maxByOrNull { it.refreshRate }
+            if (maxRefreshRateMode != null) {
+                val layoutParams = window.attributes
+                layoutParams.preferredDisplayModeId = maxRefreshRateMode.modeId
+                window.attributes = layoutParams
+            }
+        }
+
         viewModel.getLocation()
 
         setContent {

--- a/androidApp/src/main/java/com/maxrave/simpmusic/MainActivity.kt
+++ b/androidApp/src/main/java/com/maxrave/simpmusic/MainActivity.kt
@@ -221,15 +221,10 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            val display = windowManager.defaultDisplay
-            val modes = display.supportedModes
-            val maxRefreshRateMode = modes.maxByOrNull { it.refreshRate }
-            if (maxRefreshRateMode != null) {
-                val layoutParams = window.attributes
-                layoutParams.preferredDisplayModeId = maxRefreshRateMode.modeId
-                window.attributes = layoutParams
-            }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val dsp = display ?: windowManager.defaultDisplay
+            val rate = dsp.supportedModes.maxOf { it.refreshRate }
+            window.attributes = window.attributes.apply { preferredRefreshRate = rate }
         }
 
         viewModel.getLocation()


### PR DESCRIPTION
Fixes #2086

Description:
This PR enables high refresh rate (90Hz/120Hz) support for Android devices, bypassing the aggressive 60Hz lock applied by some OEM skins to Compose apps.

Implementation Details:

Implemented the preferredRefreshRate API for devices on Android R (API 30) and above.

This approach successfully signals the OS to utilize higher refresh rates without explicitly forcing a display mode, preventing unintended physical resolution downgrades on multi-resolution panels (e.g., Galaxy S20).

Preserves Variable Refresh Rate (VRR/LTPO) capabilities, allowing the system to drop frame rates on static screens for battery optimization.

Thanks again for the incredibly detailed review and for providing the minimal implementation! I completely understand the issue with the multi-resolution panels and the battery impact on LTPO displays now—that was a great learning moment.

I've pushed the updated commit using your suggested preferredRefreshRate approach for Android R+. Let me know if this looks good to go!