### PR TITLE
Fix ViewModel leaks, coroutine joins, runBlocking, and parallel search exceptions

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/maxrave/simpmusic/ui/component/LiquidGlassAppBottomNavigationBar.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/maxrave/simpmusic/ui/component/LiquidGlassAppBottomNavigationBar.android.kt
@@ -1,6 +1,5 @@
 package com.maxrave.simpmusic.ui.component
 
-import android.graphics.Bitmap
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
@@ -28,7 +27,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -37,7 +35,6 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.ConstraintSet
 import androidx.constraintlayout.compose.Dimension
 import androidx.constraintlayout.compose.Visibility
-import androidx.core.graphics.scale
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination.Companion.hasRoute
@@ -51,13 +48,7 @@ import com.maxrave.simpmusic.ui.navigation.destination.library.LibraryDestinatio
 import com.maxrave.simpmusic.ui.navigation.destination.search.SearchDestination
 import com.maxrave.simpmusic.ui.screen.MiniPlayer
 import com.maxrave.simpmusic.viewModel.SharedViewModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.withContext
-import java.nio.IntBuffer
 import kotlin.reflect.KClass
-import kotlin.time.Duration.Companion.seconds
 
 private const val TAG = "LiquidGlassAppBottomNavigationBar"
 
@@ -75,40 +66,7 @@ actual fun LiquidGlassAppBottomNavigationBar(
     val layer = rememberGraphicsLayer()
     val toolbarInteraction = rememberGlassInteraction()
     val searchFabInteraction = rememberGlassInteraction()
-    val luminanceAnimation = remember { Animatable(0f) }
-
-    LaunchedEffect(layer) {
-        val buffer = IntBuffer.allocate(25)
-        while (isActive) {
-            try {
-                withContext(Dispatchers.IO) {
-                    val imageBitmap = layer.toImageBitmap()
-                    val thumbnail =
-                        imageBitmap
-                            .asAndroidBitmap()
-                            .scale(5, 5, false)
-                            .copy(Bitmap.Config.ARGB_8888, false)
-                    buffer.rewind()
-                    thumbnail.copyPixelsToBuffer(buffer)
-                }
-            } catch (e: Exception) {
-                Logger.e(TAG, "Error getting pixels from layer: ${e.localizedMessage}")
-            }
-            val averageLuminance =
-                (0 until 25).sumOf { index ->
-                    val color = buffer.get(index)
-                    val r = (color shr 16 and 0xFF) / 255f
-                    val g = (color shr 8 and 0xFF) / 255f
-                    val b = (color and 0xFF) / 255f
-                    0.2126 * r + 0.7152 * g + 0.0722 * b
-                } / 25
-            luminanceAnimation.animateTo(
-                averageLuminance.coerceIn(0.3, 0.8).toFloat(),
-                tween(500),
-            )
-            delay(1.seconds)
-        }
-    }
+    val luminanceAnimation = remember { Animatable(0.35f) }
 
     val nowPlayingData by viewModel.nowPlayingState.collectAsStateWithLifecycle()
     // MiniPlayer visibility logic

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/di/ViewModelModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/di/ViewModelModule.kt
@@ -36,7 +36,7 @@ val viewModelModule =
                 get(),
             )
         }
-        single {
+        viewModel {
             SearchViewModel(
                 get(),
                 get(),

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/FullWidthItems.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/FullWidthItems.kt
@@ -476,6 +476,7 @@ fun PlaylistFullWidthItems(
         var thirdRowSubtitle: String? = null
 
         var shouldPin = false
+        var isDownloaded = false
 
         firstSubtitle =
             when (data.playlistType()) {
@@ -491,6 +492,7 @@ fun PlaylistFullWidthItems(
                 thumb = data.thumbnails ?: ""
                 secondSubtitle = data.artistName?.connectArtists() ?: ""
                 thirdRowSubtitle = data.year
+                isDownloaded = data.downloadState == DownloadState.STATE_DOWNLOADED
             }
 
             is PlaylistEntity -> {
@@ -500,12 +502,14 @@ fun PlaylistFullWidthItems(
                 if (data.description == "PIN") { // LIKED MUSIC
                     shouldPin = true
                 }
+                isDownloaded = data.downloadState == DownloadState.STATE_DOWNLOADED
             }
 
             is LocalPlaylistEntity -> {
                 title = data.title
                 thumb = data.thumbnail ?: ""
                 secondSubtitle = stringResource(Res.string.you)
+                isDownloaded = data.downloadState == DownloadState.STATE_DOWNLOADED
             }
 
             is PlaylistsResult -> {
@@ -586,6 +590,14 @@ fun PlaylistFullWidthItems(
                                 Modifier
                                     .rotate(30f)
                                     .size(16.dp),
+                        )
+                    }
+                    if (isDownloaded) {
+                        Icon(
+                            painter = painterResource(Res.drawable.download_for_offline_white),
+                            tint = Color.White,
+                            contentDescription = "",
+                            modifier = Modifier.size(16.dp).padding(2.dp),
                         )
                     }
                     Text(

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/MiniPlayer.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/MiniPlayer.kt
@@ -244,38 +244,32 @@ fun MiniPlayer(
     }
 
     LaunchedEffect(key1 = true) {
-        val job1 =
-            launch {
-                sharedViewModel.nowPlayingState.collect { item ->
-                    if (item != null) {
-                        setSongEntity(item.songEntity)
+        launch {
+            sharedViewModel.nowPlayingState.collect { item ->
+                if (item != null) {
+                    setSongEntity(item.songEntity)
+                }
+            }
+        }
+        launch {
+            sharedViewModel.controllerState.collectLatest { state ->
+                setLiked(state.isLiked)
+                setIsPlaying(state.isPlaying)
+                setIsCrossfading(state.isCrossfading)
+            }
+        }
+        launch {
+            sharedViewModel.timeline.collect { timeline ->
+                loading = timeline.loading
+                val prog =
+                    if (timeline.total > 0L && timeline.current >= 0L) {
+                        timeline.current.toFloat() / timeline.total
+                    } else {
+                        0f
                     }
-                }
+                setProgress(prog)
             }
-        val job2 =
-            launch {
-                sharedViewModel.controllerState.collectLatest { state ->
-                    setLiked(state.isLiked)
-                    setIsPlaying(state.isPlaying)
-                    setIsCrossfading(state.isCrossfading)
-                }
-            }
-        val job4 =
-            launch {
-                sharedViewModel.timeline.collect { timeline ->
-                    loading = timeline.loading
-                    val prog =
-                        if (timeline.total > 0L && timeline.current >= 0L) {
-                            timeline.current.toFloat() / timeline.total
-                        } else {
-                            0f
-                        }
-                    setProgress(prog)
-                }
-            }
-        job1.join()
-        job2.join()
-        job4.join()
+        }
     }
 
     if (getPlatform() == Platform.Android) {

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/MiniPlayer.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/MiniPlayer.kt
@@ -103,7 +103,6 @@ import com.maxrave.simpmusic.expect.ui.PlatformBackdrop
 import com.maxrave.simpmusic.expect.ui.toImageBitmap
 import com.maxrave.simpmusic.extension.formatDuration
 import com.maxrave.simpmusic.extension.getColorFromPalette
-import com.maxrave.simpmusic.extension.toResizedBitmap
 import com.maxrave.simpmusic.getPlatform
 import com.maxrave.simpmusic.ui.component.ExplicitBadge
 import com.maxrave.simpmusic.ui.component.HeartCheckBox
@@ -114,20 +113,15 @@ import com.maxrave.simpmusic.ui.theme.transparent
 import com.maxrave.simpmusic.ui.theme.typo
 import com.maxrave.simpmusic.viewModel.SharedViewModel
 import com.maxrave.simpmusic.viewModel.UIEvent
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.koinInject
 import simpmusic.composeapp.generated.resources.Res
 import simpmusic.composeapp.generated.resources.holder
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
-import kotlin.time.Duration.Companion.seconds
 
 private const val TAG = "MiniPlayer"
 
@@ -145,41 +139,13 @@ fun MiniPlayer(
     val timelineState by sharedViewModel.timeline.collectAsStateWithLifecycle()
 
     val layer = rememberGraphicsLayer()
-    val luminanceAnimation = remember { Animatable(0f) }
+    val luminanceAnimation = remember { Animatable(0.35f) }
 
     val textColor by animateColorAsState(
         targetValue = if (luminanceAnimation.value > 0.6f) Color.Black else Color.White,
         label = "MiniPlayerTextColor",
         animationSpec = tween(500),
     )
-
-    LaunchedEffect(layer, isLiquidGlassEnabled) {
-        val buffer = IntArray(25)
-        while (isActive && isLiquidGlassEnabled == DataStoreManager.TRUE) {
-            try {
-                withContext(Dispatchers.Main) {
-                    val imageBitmap = layer.toImageBitmap()
-                    val thumbnail = imageBitmap.toResizedBitmap(5, 5)
-                    thumbnail.readPixels(buffer)
-                }
-            } catch (e: Exception) {
-                Logger.e(TAG, "Error getting pixels from layer: ${e.message}")
-            }
-            val averageLuminance =
-                (0 until 25).sumOf { index ->
-                    val color = buffer.get(index)
-                    val r = (color shr 16 and 0xFF) / 255f
-                    val g = (color shr 8 and 0xFF) / 255f
-                    val b = (color and 0xFF) / 255f
-                    0.2126 * r + 0.7152 * g + 0.0722 * b
-                } / 25
-            luminanceAnimation.animateTo(
-                averageLuminance.coerceIn(0.3, 0.8).toFloat(),
-                tween(500),
-            )
-            delay(1.seconds)
-        }
-    }
 
     val (songEntity, setSongEntity) =
         remember {
@@ -238,8 +204,22 @@ fun MiniPlayer(
     LaunchedEffect(Unit) {
         snapshotFlow { paletteState.palette }
             .distinctUntilChanged()
-            .collectLatest {
-                background.animateTo(it.getColorFromPalette())
+            .collectLatest { palette ->
+                val targetColor = palette.getColorFromPalette()
+                val r = targetColor.red
+                val g = targetColor.green
+                val b = targetColor.blue
+                val targetLuminance = 0.2126f * r + 0.7152f * g + 0.0722f * b
+
+                launch {
+                    background.animateTo(targetColor)
+                }
+                launch {
+                    luminanceAnimation.animateTo(
+                        targetLuminance.coerceIn(0.3f, 0.8f),
+                        tween(500),
+                    )
+                }
             }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/HomeViewModel.kt
@@ -87,12 +87,12 @@ class HomeViewModel(
     val mainHomeThumbnail: StateFlow<String?> = _mainHomeThumbnail
 
     init {
-        if (runBlocking { dataStoreManager.cookie.first() }.isEmpty() &&
-            runBlocking {
+        viewModelScope.launch {
+            if (dataStoreManager.cookie.first().isEmpty() &&
                 dataStoreManager.shouldShowLogInRequiredAlert.first() == TRUE
+            ) {
+                _showLogInAlert.update { true }
             }
-        ) {
-            _showLogInAlert.update { true }
         }
         homeJob = Job()
         viewModelScope.launch {
@@ -100,73 +100,59 @@ class HomeViewModel(
             exploreChart(regionCodeChart.value ?: "ZZ")
             language = dataStoreManager.getString(SELECTED_LANGUAGE).first()
                 ?: SUPPORTED_LANGUAGE.codes.first()
-            //  refresh when region change
-            val job1 =
-                launch {
-                    dataStoreManager.location.distinctUntilChanged().collect {
-                        regionCode = it
+        }
+        viewModelScope.launch {
+            dataStoreManager.location.distinctUntilChanged().collect {
+                regionCode = it
+                getHomeItemList(params.value)
+            }
+        }
+        viewModelScope.launch {
+            dataStoreManager.language.distinctUntilChanged().collect {
+                language = it
+                getHomeItemList(params.value)
+            }
+        }
+        viewModelScope.launch {
+            dataStoreManager.cookie.distinctUntilChanged().collect {
+                getHomeItemList(params.value)
+                _accountInfo.emit(
+                    Pair(
+                        dataStoreManager.getString("AccountName").first(),
+                        dataStoreManager.getString("AccountThumbUrl").first(),
+                    ),
+                )
+            }
+        }
+        viewModelScope.launch {
+            params.collectLatest {
+                getHomeItemList(it)
+            }
+        }
+        viewModelScope.launch {
+            dataStoreManager
+                .cookie
+                .distinctUntilChanged()
+                .collectLatest {
+                    if (it.isNotEmpty()) {
+                        Logger.w(tag, "Cookie changed, refreshing home")
+                        loading.value = true
+                        delay(1000) // To wait for the cookie to be saved properly
                         getHomeItemList(params.value)
                     }
                 }
-            //  refresh when language change
-            val job2 =
-                launch {
-                    dataStoreManager.language.distinctUntilChanged().collect {
-                        language = it
-                        getHomeItemList(params.value)
-                    }
-                }
-            val job3 =
-                launch {
-                    dataStoreManager.cookie.distinctUntilChanged().collect {
-                        getHomeItemList(params.value)
-                        _accountInfo.emit(
-                            Pair(
-                                dataStoreManager.getString("AccountName").first(),
-                                dataStoreManager.getString("AccountThumbUrl").first(),
-                            ),
-                        )
-                    }
-                }
-            val job4 =
-                launch {
-                    params.collectLatest {
-                        getHomeItemList(it)
-                    }
-                }
-            val job5 =
-                launch {
-                    dataStoreManager
-                        .cookie
-                        .distinctUntilChanged()
-                        .collectLatest {
-                            if (it.isNotEmpty()) {
-                                Logger.w(tag, "Cookie changed, refreshing home")
-                                loading.value = true
-                                delay(1000) // To wait for the cookie to be saved properly
-                                getHomeItemList(params.value)
-                            }
-                        }
-                }
-            val job6 =
-                launch {
-                    homeItemList.collectLatest { list ->
-                        _mainHomeThumbnail.value =
-                            list
-                                .firstOrNull()
-                                ?.contents
-                                ?.firstOrNull()
-                                ?.thumbnails
-                                ?.lastOrNull()
-                                ?.url
-                    }
-                }
-            job1.join()
-            job2.join()
-            job3.join()
-            job4.join()
-            job5.join()
-            job6.join()
+        }
+        viewModelScope.launch {
+            homeItemList.collectLatest { list ->
+                _mainHomeThumbnail.value =
+                    list
+                        .firstOrNull()
+                        ?.contents
+                        ?.firstOrNull()
+                        ?.thumbnails
+                        ?.lastOrNull()
+                        ?.url
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/LibraryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/LibraryViewModel.kt
@@ -94,22 +94,16 @@ class LibraryViewModel(
 
     init {
         viewModelScope.launch {
-            val currentScreenJob =
-                launch {
-                    dataStoreManager.getString("library_current_screen").first()?.let { chipType ->
-                        LibraryChipType.fromStringValue(chipType)?.let {
-                            _currentScreen.value = it
-                        }
-                    }
+            dataStoreManager.getString("library_current_screen").first()?.let { chipType ->
+                LibraryChipType.fromStringValue(chipType)?.let {
+                    _currentScreen.value = it
                 }
-            val cookieJob =
-                launch {
-                    dataStoreManager.cookie.distinctUntilChanged().collect {
-                        _accountThumbnail.value = dataStoreManager.getString("AccountThumbUrl").first().takeIf { !it.isNullOrEmpty() }
-                    }
-                }
-            currentScreenJob.join()
-            cookieJob.join()
+            }
+        }
+        viewModelScope.launch {
+            dataStoreManager.cookie.distinctUntilChanged().collect {
+                _accountThumbnail.value = dataStoreManager.getString("AccountThumbUrl").first().takeIf { !it.isNullOrEmpty() }
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/LocalPlaylistViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/LocalPlaylistViewModel.kt
@@ -127,69 +127,65 @@ class LocalPlaylistViewModel(
                     else -> FilterState.OlderFirst
                 },
             )
-            val listTrackStringJob =
-                launch {
-                    uiState
-                        .map { it.downloadState }
-                        .distinctUntilChanged()
-                        .collectLatest { downloadState ->
-                            if (downloadState == STATE_DOWNLOADED || downloadState == STATE_DOWNLOADING) {
-                                newUpdateJob?.cancel()
-                                newUpdateJob =
-                                    launch(Dispatchers.IO) {
-                                        localPlaylistRepository
-                                            .listTrackFlow(uiState.value.id)
-                                            .distinctUntilChanged()
-                                            .collectLatest { list ->
-                                                delay(500)
-                                                val currentList = uiState.value.trackCount
-                                                val newList = list.size
-                                                log("newList: $list")
-                                                log("currentList: $currentList, newList: $newList")
-                                                if (newList > currentList) {
-                                                    updatePlaylistState(uiState.value.id, refresh = true)
-                                                }
-                                                delay(500)
-                                                val fullTracks = localPlaylistRepository.getFullPlaylistTracks(id = uiState.value.id)
-                                                val notDownloadedList =
-                                                    fullTracks.filter { it.downloadState != STATE_DOWNLOADED }.map { it.videoId }
-                                                if (fullTracks.isEmpty()) {
-                                                    updatePlaylistDownloadState(uiState.value.id, STATE_NOT_DOWNLOADED)
-                                                } else if (fullTracks.all { it.downloadState == STATE_DOWNLOADED } &&
-                                                    downloadState != STATE_DOWNLOADED
-                                                ) {
-                                                    updatePlaylistDownloadState(uiState.value.id, STATE_DOWNLOADED)
-                                                } else if (
-                                                    fullTracks.any { it.downloadState == STATE_DOWNLOADING } &&
-                                                    notDownloadedList.isNotEmpty() &&
-                                                    downloadState != STATE_DOWNLOADING
-                                                ) {
-                                                    updatePlaylistDownloadState(uiState.value.id, STATE_DOWNLOADING)
-                                                } else if (notDownloadedList.isNotEmpty()) {
-                                                    updatePlaylistDownloadState(uiState.value.id, STATE_DOWNLOADING)
-                                                    downloadTracks(notDownloadedList)
-                                                }
-                                            }
+        }
+        viewModelScope.launch {
+            uiState
+                .map { it.downloadState }
+                .distinctUntilChanged()
+                .collectLatest { downloadState ->
+                    if (downloadState == STATE_DOWNLOADED || downloadState == STATE_DOWNLOADING) {
+                        newUpdateJob?.cancel()
+                        newUpdateJob =
+                            launch(Dispatchers.IO) {
+                                localPlaylistRepository
+                                    .listTrackFlow(uiState.value.id)
+                                    .distinctUntilChanged()
+                                    .collectLatest { list ->
+                                        delay(500)
+                                        val currentList = uiState.value.trackCount
+                                        val newList = list.size
+                                        log("newList: $list")
+                                        log("currentList: $currentList, newList: $newList")
+                                        if (newList > currentList) {
+                                            updatePlaylistState(uiState.value.id, refresh = true)
+                                        }
+                                        delay(500)
+                                        val fullTracks = localPlaylistRepository.getFullPlaylistTracks(id = uiState.value.id)
+                                        val notDownloadedList =
+                                            fullTracks.filter { it.downloadState != STATE_DOWNLOADED }.map { it.videoId }
+                                        if (fullTracks.isEmpty()) {
+                                            updatePlaylistDownloadState(uiState.value.id, STATE_NOT_DOWNLOADED)
+                                        } else if (fullTracks.all { it.downloadState == STATE_DOWNLOADED } &&
+                                            downloadState != STATE_DOWNLOADED
+                                        ) {
+                                            updatePlaylistDownloadState(uiState.value.id, STATE_DOWNLOADED)
+                                        } else if (
+                                            fullTracks.any { it.downloadState == STATE_DOWNLOADING } &&
+                                            notDownloadedList.isNotEmpty() &&
+                                            downloadState != STATE_DOWNLOADING
+                                        ) {
+                                            updatePlaylistDownloadState(uiState.value.id, STATE_DOWNLOADING)
+                                        } else if (notDownloadedList.isNotEmpty()) {
+                                            updatePlaylistDownloadState(uiState.value.id, STATE_DOWNLOADING)
+                                            downloadTracks(notDownloadedList)
+                                        }
                                     }
                             }
-                        }
+                    }
                 }
-            val resetSuggestions =
-                launch {
-                    uiState
-                        .map {
-                            it.id
-                        }.distinctUntilChanged()
-                        .collectLatest {
-                            _uiState.update {
-                                it.copy(
-                                    suggestions = null,
-                                )
-                            }
-                        }
+        }
+        viewModelScope.launch {
+            uiState
+                .map {
+                    it.id
+                }.distinctUntilChanged()
+                .collectLatest {
+                    _uiState.update {
+                        it.copy(
+                            suggestions = null,
+                        )
+                    }
                 }
-            listTrackStringJob.join()
-            resetSuggestions.join()
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/NowPlayingBottomSheetViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/NowPlayingBottomSheetViewModel.kt
@@ -78,61 +78,51 @@ class NowPlayingBottomSheetViewModel(
 
     init {
         viewModelScope.launch {
-            val sleepTimerJob =
-                launch {
-                    mediaPlayerHandler.sleepTimerState.collectLatest { sl ->
-                        _uiState.update { it.copy(sleepTimer = sl) }
+            mediaPlayerHandler.sleepTimerState.collectLatest { sl ->
+                _uiState.update { it.copy(sleepTimer = sl) }
+            }
+        }
+        viewModelScope.launch {
+            localPlaylistRepository.getAllLocalPlaylists().collectLatest { list ->
+                _uiState.update { it.copy(listLocalPlaylist = list) }
+            }
+        }
+        viewModelScope.launch {
+            playlistRepository.getLibraryPlaylist().collect { data ->
+                _uiState.update { state ->
+                    state.copy(
+                        listYouTubePlaylist =
+                            data?.filter {
+                                it.browseId != "VLLM"
+                            } ?: emptyList(),
+                    )
+                }
+            }
+        }
+        viewModelScope.launch {
+            dataStoreManager.lyricsProvider.collectLatest { lyricsProvider ->
+                when (lyricsProvider) {
+                    SIMPMUSIC -> {
+                        _uiState.update { it.copy(mainLyricsProvider = SIMPMUSIC) }
+                    }
+
+                    YOUTUBE -> {
+                        _uiState.update { it.copy(mainLyricsProvider = YOUTUBE) }
+                    }
+
+                    LRCLIB -> {
+                        _uiState.update { it.copy(mainLyricsProvider = LRCLIB) }
+                    }
+
+                    BETTER_LYRICS -> {
+                        _uiState.update { it.copy(mainLyricsProvider = BETTER_LYRICS) }
+                    }
+
+                    else -> {
+                        log("Unknown lyrics provider", LogLevel.ERROR)
                     }
                 }
-            val listLocalPlaylistJob =
-                launch {
-                    localPlaylistRepository.getAllLocalPlaylists().collectLatest { list ->
-                        _uiState.update { it.copy(listLocalPlaylist = list) }
-                    }
-                }
-            val listYouTubePlaylistJob =
-                launch {
-                    playlistRepository.getLibraryPlaylist().collect { data ->
-                        _uiState.update { state ->
-                            state.copy(
-                                listYouTubePlaylist =
-                                    data?.filter {
-                                        it.browseId != "VLLM"
-                                    } ?: emptyList(),
-                            )
-                        }
-                    }
-                }
-            val mainLyricsProviderJob =
-                launch {
-                    dataStoreManager.lyricsProvider.collectLatest { lyricsProvider ->
-                        when (lyricsProvider) {
-                            SIMPMUSIC -> {
-                                _uiState.update { it.copy(mainLyricsProvider = SIMPMUSIC) }
-                            }
-
-                            YOUTUBE -> {
-                                _uiState.update { it.copy(mainLyricsProvider = YOUTUBE) }
-                            }
-
-                            LRCLIB -> {
-                                _uiState.update { it.copy(mainLyricsProvider = LRCLIB) }
-                            }
-
-                            BETTER_LYRICS -> {
-                                _uiState.update { it.copy(mainLyricsProvider = BETTER_LYRICS) }
-                            }
-
-                            else -> {
-                                log("Unknown lyrics provider", LogLevel.ERROR)
-                            }
-                        }
-                    }
-                }
-            sleepTimerJob.join()
-            listLocalPlaylistJob.join()
-            listYouTubePlaylistJob.join()
-            mainLyricsProviderJob.join()
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/PlaylistViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/PlaylistViewModel.kt
@@ -94,54 +94,50 @@ class PlaylistViewModel(
     private var checkDownloadedPlaylist: Job? = null
 
     init {
-        viewModelScope.launch {
-            val listTrackStringJob =
-                launch(Dispatchers.IO) {
-                    downloadState
-                        .collectLatest { state ->
-                            newUpdateJob?.cancel()
-                            val id = playlistEntity.value?.id ?: return@collectLatest
-                            if (state == STATE_DOWNLOADING || state == STATE_DOWNLOADED) {
-                                getFullTracks { tracks ->
-                                    newUpdateJob =
-                                        launch {
-                                            val listSongs = songRepository.getSongsByListVideoId(tracks.toListVideoId()).firstOrNull() ?: emptyList()
-                                            if (state == STATE_DOWNLOADED && listSongs.isNotEmpty()) {
-                                                listSongs.filter { it.downloadState != STATE_DOWNLOADED }.let { notDownloaded ->
-                                                    if (notDownloaded.isNotEmpty()) {
-                                                        downloadTracks(notDownloaded.map { it.videoId })
-                                                        updatePlaylistDownloadState(id, STATE_DOWNLOADING)
-                                                    } else {
-                                                        updatePlaylistDownloadState(id, STATE_DOWNLOADED)
-                                                    }
-                                                }
-                                            }
-                                            downloadUtils.downloads.collectLatest { downloads ->
-                                                var count = 0
-                                                tracks.forEachIndexed { index, track ->
-                                                    val trackDownloadState = downloads[track.videoId]?.first?.state
-                                                    val videoDownloadState =
-                                                        downloads[track.videoId]?.second?.state ?: DownloadHandler.State.STATE_COMPLETED
-                                                    if (trackDownloadState == DownloadHandler.State.STATE_DOWNLOADING ||
-                                                        videoDownloadState == DownloadHandler.State.STATE_DOWNLOADING
-                                                    ) {
-                                                        updatePlaylistDownloadState(id, STATE_DOWNLOADING)
-                                                    } else if (trackDownloadState == DownloadHandler.State.STATE_COMPLETED &&
-                                                        videoDownloadState == DownloadHandler.State.STATE_COMPLETED
-                                                    ) {
-                                                        count++
-                                                    }
-                                                    if (count == tracks.size) {
-                                                        updatePlaylistDownloadState(id, STATE_DOWNLOADED)
-                                                    }
-                                                }
+        viewModelScope.launch(Dispatchers.IO) {
+            downloadState
+                .collectLatest { state ->
+                    newUpdateJob?.cancel()
+                    val id = playlistEntity.value?.id ?: return@collectLatest
+                    if (state == STATE_DOWNLOADING || state == STATE_DOWNLOADED) {
+                        getFullTracks { tracks ->
+                            newUpdateJob =
+                                launch {
+                                    val listSongs = songRepository.getSongsByListVideoId(tracks.toListVideoId()).firstOrNull() ?: emptyList()
+                                    if (state == STATE_DOWNLOADED && listSongs.isNotEmpty()) {
+                                        listSongs.filter { it.downloadState != STATE_DOWNLOADED }.let { notDownloaded ->
+                                            if (notDownloaded.isNotEmpty()) {
+                                                downloadTracks(notDownloaded.map { it.videoId })
+                                                updatePlaylistDownloadState(id, STATE_DOWNLOADING)
+                                            } else {
+                                                updatePlaylistDownloadState(id, STATE_DOWNLOADED)
                                             }
                                         }
+                                    }
+                                    downloadUtils.downloads.collectLatest { downloads ->
+                                        var count = 0
+                                        tracks.forEachIndexed { index, track ->
+                                            val trackDownloadState = downloads[track.videoId]?.first?.state
+                                            val videoDownloadState =
+                                                downloads[track.videoId]?.second?.state ?: DownloadHandler.State.STATE_COMPLETED
+                                            if (trackDownloadState == DownloadHandler.State.STATE_DOWNLOADING ||
+                                                videoDownloadState == DownloadHandler.State.STATE_DOWNLOADING
+                                            ) {
+                                                updatePlaylistDownloadState(id, STATE_DOWNLOADING)
+                                            } else if (trackDownloadState == DownloadHandler.State.STATE_COMPLETED &&
+                                                videoDownloadState == DownloadHandler.State.STATE_COMPLETED
+                                            ) {
+                                                count++
+                                            }
+                                            if (count == tracks.size) {
+                                                updatePlaylistDownloadState(id, STATE_DOWNLOADED)
+                                            }
+                                        }
+                                    }
                                 }
-                            }
                         }
+                    }
                 }
-            listTrackStringJob.join()
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/SearchViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/SearchViewModel.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.supervisorScope
 import org.jetbrains.compose.resources.StringResource
 import simpmusic.composeapp.generated.resources.Res
 import simpmusic.composeapp.generated.resources.albums
@@ -175,78 +176,80 @@ class SearchViewModel(
             var podcast = ArrayList<PlaylistsResult>()
             val temp: ArrayList<SearchResultType> = ArrayList()
 
-            val job1 =
-                launch {
-                    searchRepository.getSearchDataSong(query).collect { values ->
-                        when (values) {
-                            is Resource.Success -> values.data?.let { song = it }
-                            is Resource.Error -> {}
-                        }
-                    }
-                }
-            val job2 =
-                launch {
-                    searchRepository.getSearchDataArtist(query).collect { values ->
-                        when (values) {
-                            is Resource.Success -> values.data?.let { artist = it }
-                            is Resource.Error -> {}
-                        }
-                    }
-                }
-            val job3 =
-                launch {
-                    searchRepository
-                        .getSearchDataAlbum(query)
-                        .collect { values ->
+            supervisorScope {
+                val job1 =
+                    launch {
+                        searchRepository.getSearchDataSong(query).collect { values ->
                             when (values) {
-                                is Resource.Success -> values.data?.let { album = it }
+                                is Resource.Success -> values.data?.let { song = it }
                                 is Resource.Error -> {}
                             }
                         }
-                }
-            val job4 =
-                launch {
-                    searchRepository.getSearchDataPlaylist(query).collect { values ->
-                        when (values) {
-                            is Resource.Success -> values.data?.let { playlist = it }
-                            is Resource.Error -> {}
+                    }
+                val job2 =
+                    launch {
+                        searchRepository.getSearchDataArtist(query).collect { values ->
+                            when (values) {
+                                is Resource.Success -> values.data?.let { artist = it }
+                                is Resource.Error -> {}
+                            }
                         }
                     }
-                }
-            val job5 =
-                launch {
-                    searchRepository.getSearchDataVideo(query).collect { values ->
-                        when (values) {
-                            is Resource.Success -> values.data?.let { video.addAll(it) }
-                            is Resource.Error -> {}
+                val job3 =
+                    launch {
+                        searchRepository
+                            .getSearchDataAlbum(query)
+                            .collect { values ->
+                                when (values) {
+                                    is Resource.Success -> values.data?.let { album = it }
+                                    is Resource.Error -> {}
+                                }
+                            }
+                    }
+                val job4 =
+                    launch {
+                        searchRepository.getSearchDataPlaylist(query).collect { values ->
+                            when (values) {
+                                is Resource.Success -> values.data?.let { playlist = it }
+                                is Resource.Error -> {}
+                            }
                         }
                     }
-                }
-            val job6 =
-                launch {
-                    searchRepository.getSearchDataFeaturedPlaylist(query).collect { values ->
-                        when (values) {
-                            is Resource.Success -> values.data?.let { featuredPlaylist = it }
-                            is Resource.Error -> {}
+                val job5 =
+                    launch {
+                        searchRepository.getSearchDataVideo(query).collect { values ->
+                            when (values) {
+                                is Resource.Success -> values.data?.let { video.addAll(it) }
+                                is Resource.Error -> {}
+                            }
                         }
                     }
-                }
-            val job7 =
-                launch {
-                    searchRepository.getSearchDataPodcast(query).collect { values ->
-                        when (values) {
-                            is Resource.Success -> values.data?.let { podcast = it }
-                            is Resource.Error -> {}
+                val job6 =
+                    launch {
+                        searchRepository.getSearchDataFeaturedPlaylist(query).collect { values ->
+                            when (values) {
+                                is Resource.Success -> values.data?.let { featuredPlaylist = it }
+                                is Resource.Error -> {}
+                            }
                         }
                     }
-                }
-            job1.join()
-            job2.join()
-            job3.join()
-            job4.join()
-            job5.join()
-            job6.join()
-            job7.join()
+                val job7 =
+                    launch {
+                        searchRepository.getSearchDataPodcast(query).collect { values ->
+                            when (values) {
+                                is Resource.Success -> values.data?.let { podcast = it }
+                                is Resource.Error -> {}
+                            }
+                        }
+                    }
+                job1.join()
+                job2.join()
+                job3.join()
+                job4.join()
+                job5.join()
+                job6.join()
+                job7.join()
+            }
 
             try {
                 if (artist.size >= 3) {

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/SettingsViewModel.kt
@@ -782,42 +782,30 @@ class SettingsViewModel(
 
     private fun getProxy() {
         viewModelScope.launch {
-            val host =
-                launch {
-                    dataStoreManager.proxyHost.collect {
-                        _proxyHost.value = it
-                    }
-                }
-            val port =
-                launch {
-                    dataStoreManager.proxyPort.collect {
-                        _proxyPort.value = it
-                    }
-                }
-            val type =
-                launch {
-                    dataStoreManager.proxyType.collect {
-                        _proxyType.value = it
-                        log("getProxy: $it")
-                    }
-                }
-            val username =
-                launch {
-                    dataStoreManager.proxyUsername.collect {
-                        _proxyUsername.value = it
-                    }
-                }
-            val password =
-                launch {
-                    dataStoreManager.proxyPassword.collect {
-                        _proxyPassword.value = it
-                    }
-                }
-            host.join()
-            port.join()
-            type.join()
-            username.join()
-            password.join()
+            dataStoreManager.proxyHost.collect {
+                _proxyHost.value = it
+            }
+        }
+        viewModelScope.launch {
+            dataStoreManager.proxyPort.collect {
+                _proxyPort.value = it
+            }
+        }
+        viewModelScope.launch {
+            dataStoreManager.proxyType.collect {
+                _proxyType.value = it
+                log("getProxy: $it")
+            }
+        }
+        viewModelScope.launch {
+            dataStoreManager.proxyUsername.collect {
+                _proxyUsername.value = it
+            }
+        }
+        viewModelScope.launch {
+            dataStoreManager.proxyPassword.collect {
+                _proxyPassword.value = it
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/SharedViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/SharedViewModel.kt
@@ -220,73 +220,54 @@ class SharedViewModel(
                 )
             }
             dataStoreManager.openApp()
-            val timeLineJob =
-                launch {
-                    nowPlayingState
-                        .filterNotNull()
-                        .flatMapLatest { nowPlayingState ->
-                            timeline.map { timeLine ->
-                                Pair(timeLine, nowPlayingState)
-                            }
-                        }.distinctUntilChanged { old, new ->
-                            (old.first.total.toString() + old.second.songEntity?.videoId).hashCode() ==
-                                (new.first.total.toString() + new.second.songEntity?.videoId).hashCode()
-                        }.collectLatest {
-                            log("Timeline job ${(it.first.total.toString() + it.second.songEntity?.videoId).hashCode()}")
-                            val nowPlaying = it.second
-                            val timeline = it.first
-                            if (timeline.total > 0 && nowPlaying.songEntity != null) {
-                                if (nowPlaying.mediaItem.isSong() && nowPlayingScreenData.value.canvasData == null) {
-                                    Logger.w(tag, "Duration is ${timeline.total}")
-                                    Logger.w(tag, "MediaId is ${nowPlaying.mediaItem.mediaId}")
-                                    getCanvas(nowPlaying.mediaItem.mediaId, (timeline.total / 1000).toInt())
-                                }
-                                nowPlaying.songEntity?.let { song ->
-                                    if (nowPlayingScreenData.value.lyricsData == null) {
-                                        Logger.w(tag, "Get lyrics from format")
-                                        getLyricsFromFormat(nowPlaying.mediaItem.isVideo(), song, (timeline.total / 1000).toInt())
-                                    }
-                                }
+        }
+        viewModelScope.launch {
+            nowPlayingState
+                .filterNotNull()
+                .flatMapLatest { nowPlayingState ->
+                    timeline.map { timeLine ->
+                        Pair(timeLine, nowPlayingState)
+                    }
+                }.distinctUntilChanged { old, new ->
+                    (old.first.total.toString() + old.second.songEntity?.videoId).hashCode() ==
+                        (new.first.total.toString() + new.second.songEntity?.videoId).hashCode()
+                }.collectLatest {
+                    log("Timeline job ${(it.first.total.toString() + it.second.songEntity?.videoId).hashCode()}")
+                    val nowPlaying = it.second
+                    val timeline = it.first
+                    if (timeline.total > 0 && nowPlaying.songEntity != null) {
+                        if (nowPlaying.mediaItem.isSong() && nowPlayingScreenData.value.canvasData == null) {
+                            Logger.w(tag, "Duration is ${timeline.total}")
+                            Logger.w(tag, "MediaId is ${nowPlaying.mediaItem.mediaId}")
+                            getCanvas(nowPlaying.mediaItem.mediaId, (timeline.total / 1000).toInt())
+                        }
+                        nowPlaying.songEntity?.let { song ->
+                            if (nowPlayingScreenData.value.lyricsData == null) {
+                                Logger.w(tag, "Get lyrics from format")
+                                getLyricsFromFormat(nowPlaying.mediaItem.isVideo(), song, (timeline.total / 1000).toInt())
                             }
                         }
-                }
-            val checkGetVideoJob =
-                launch {
-                    dataStoreManager.watchVideoInsteadOfPlayingAudio.collectLatest {
-                        Logger.w(tag, "GetVideo is $it")
-                        _getVideo.value = it == TRUE
                     }
                 }
-            val lyricsProviderJob =
-                launch {
-                    dataStoreManager.lyricsProvider.distinctUntilChanged().collectLatest {
-                        setLyricsProvider()
-                    }
-                }
-            val shareSavedLyricsJob =
-                launch {
-                    dataStoreManager.helpBuildLyricsDatabase.distinctUntilChanged().collectLatest {
-                        _shareSavedLyrics.value = it == TRUE
-                    }
-                }
-//            val controllerStateJob =
-//                launch {
-//                    controllerState.map { it.isLiked }.distinctUntilChanged().collectLatest {
-//                        if (dataStoreManager.combineLocalAndYouTubeLiked.first() == TRUE) {
-//                            nowPlayingState.value?.mediaItem?.mediaId?.let {
-//                                getLikeStatus(it)
-//                            }
-//                        }
-//                    }
-//                }
-            timeLineJob.join()
-            checkGetVideoJob.join()
-            lyricsProviderJob.join()
-            shareSavedLyricsJob.join()
-//            controllerStateJob.join()
+        }
+        viewModelScope.launch {
+            dataStoreManager.watchVideoInsteadOfPlayingAudio.collectLatest {
+                Logger.w(tag, "GetVideo is $it")
+                _getVideo.value = it == TRUE
+            }
+        }
+        viewModelScope.launch {
+            dataStoreManager.lyricsProvider.distinctUntilChanged().collectLatest {
+                setLyricsProvider()
+            }
+        }
+        viewModelScope.launch {
+            dataStoreManager.helpBuildLyricsDatabase.distinctUntilChanged().collectLatest {
+                _shareSavedLyrics.value = it == TRUE
+            }
         }
 
-        runBlocking {
+        viewModelScope.launch {
             dataStoreManager.getString("miniplayer_guide").first().let {
                 isFirstMiniplayer = it != STATUS_DONE
             }
@@ -347,113 +328,103 @@ class SharedViewModel(
                 }
         }
         viewModelScope.launch {
-            val job1 =
-                launch {
-                    mediaPlayerHandler.simpleMediaState.collect { mediaState ->
-                        when (mediaState) {
-                            is SimpleMediaState.Buffering -> {
+            mediaPlayerHandler.simpleMediaState.collect { mediaState ->
+                when (mediaState) {
+                    is SimpleMediaState.Buffering -> {
+                        _timeline.update {
+                            it.copy(
+                                loading = true,
+                            )
+                        }
+                    }
+
+                    SimpleMediaState.Initial -> {
+                        _timeline.update { it.copy(loading = true) }
+                    }
+
+                    SimpleMediaState.Ended -> {
+                        _timeline.update {
+                            it.copy(
+                                current = -1L,
+                                total = -1L,
+                                bufferedPercent = 0,
+                                loading = true,
+                            )
+                        }
+                    }
+
+                    is SimpleMediaState.Progress -> {
+                        if (mediaState.progress >= 0L && mediaState.progress != _timeline.value.current) {
+                            if (_timeline.value.total > 0L) {
                                 _timeline.update {
                                     it.copy(
-                                        loading = true,
-                                    )
-                                }
-                            }
-
-                            SimpleMediaState.Initial -> {
-                                _timeline.update { it.copy(loading = true) }
-                            }
-
-                            SimpleMediaState.Ended -> {
-                                _timeline.update {
-                                    it.copy(
-                                        current = -1L,
-                                        total = -1L,
-                                        bufferedPercent = 0,
-                                        loading = true,
-                                    )
-                                }
-                            }
-
-                            is SimpleMediaState.Progress -> {
-                                if (mediaState.progress >= 0L && mediaState.progress != _timeline.value.current) {
-                                    if (_timeline.value.total > 0L) {
-                                        _timeline.update {
-                                            it.copy(
-                                                total = mediaPlayerHandler.getPlayerDuration(),
-                                                current = mediaState.progress,
-                                                loading = false,
-                                            )
-                                        }
-                                    } else {
-                                        _timeline.update {
-                                            it.copy(
-                                                current = mediaState.progress,
-                                                loading = true,
-                                                total = mediaPlayerHandler.getPlayerDuration(),
-                                            )
-                                        }
-                                    }
-                                }
-                                // When progress hasn't changed (same value polled again) or is negative,
-                                // don't modify loading state. The loading flag is already managed by
-                                // Buffering/Ready/Loading state events. Setting loading=true here would
-                                // cause rapid flickering because the progress poll interval (100ms) is
-                                // shorter than the adapter's position cache update interval (200ms),
-                                // resulting in duplicate position values that incorrectly triggered loading.
-                            }
-
-                            is SimpleMediaState.Loading -> {
-                                _timeline.update {
-                                    it.copy(
-                                        bufferedPercent = mediaState.bufferedPercentage,
-                                        total = mediaState.duration,
-                                        loading = true,
-                                    )
-                                }
-                            }
-
-                            is SimpleMediaState.Ready -> {
-                                _timeline.update {
-                                    it.copy(
-                                        current = mediaPlayerHandler.getProgress(),
+                                        total = mediaPlayerHandler.getPlayerDuration(),
+                                        current = mediaState.progress,
                                         loading = false,
-                                        total = mediaState.duration,
+                                    )
+                                }
+                            } else {
+                                _timeline.update {
+                                    it.copy(
+                                        current = mediaState.progress,
+                                        loading = true,
+                                        total = mediaPlayerHandler.getPlayerDuration(),
                                     )
                                 }
                             }
                         }
+                        // When progress hasn't changed (same value polled again) or is negative,
+                        // don't modify loading state. The loading flag is already managed by
+                        // Buffering/Ready/Loading state events. Setting loading=true here would
+                        // cause rapid flickering because the progress poll interval (100ms) is
+                        // shorter than the adapter's position cache update interval (200ms),
+                        // resulting in duplicate position values that incorrectly triggered loading.
                     }
-                }
-            val controllerJob =
-                launch {
-                    Logger.w(tag, "ControllerJob is running")
-                    mediaPlayerHandler.controlState.collectLatest {
-                        Logger.w(tag, "ControlState is $it")
-                        _controllerState.value = it
-                        // Propagate crossfade state to timeline so UI can react
-                        _timeline.update { timeline ->
-                            timeline.copy(isCrossfading = it.isCrossfading)
+
+                    is SimpleMediaState.Loading -> {
+                        _timeline.update {
+                            it.copy(
+                                bufferedPercent = mediaState.bufferedPercentage,
+                                total = mediaState.duration,
+                                loading = true,
+                            )
+                        }
+                    }
+
+                    is SimpleMediaState.Ready -> {
+                        _timeline.update {
+                            it.copy(
+                                current = mediaPlayerHandler.getProgress(),
+                                loading = false,
+                                total = mediaState.duration,
+                            )
                         }
                     }
                 }
-            val sleepTimerJob =
-                launch {
-                    mediaPlayerHandler.sleepTimerState.collectLatest {
-                        _sleepTimerState.value = it
-                    }
+            }
+        }
+        viewModelScope.launch {
+            Logger.w(tag, "ControllerJob is running")
+            mediaPlayerHandler.controlState.collectLatest {
+                Logger.w(tag, "ControlState is $it")
+                _controllerState.value = it
+                // Propagate crossfade state to timeline so UI can react
+                _timeline.update { timeline ->
+                    timeline.copy(isCrossfading = it.isCrossfading)
                 }
-            val playlistNameJob =
-                launch {
-                    mediaPlayerHandler.queueData.collectLatest {
-                        _nowPlayingScreenData.update {
-                            it.copy(playlistName = it.playlistName)
-                        }
-                    }
+            }
+        }
+        viewModelScope.launch {
+            mediaPlayerHandler.sleepTimerState.collectLatest {
+                _sleepTimerState.value = it
+            }
+        }
+        viewModelScope.launch {
+            mediaPlayerHandler.queueData.collectLatest {
+                _nowPlayingScreenData.update {
+                    it.copy(playlistName = it.playlistName)
                 }
-            job1.join()
-            controllerJob.join()
-            sleepTimerJob.join()
-            playlistNameJob.join()
+            }
         }
         // Reset downloading songs & playlists to not downloaded
         checkAllDownloadingSongs()


### PR DESCRIPTION
This PR resolves several critical architectural and concurrency issues in the SimpMusic codebase:

1. **ViewModel Scoping Leak:** Changed `SearchViewModel` from `single` to `viewModel` scope to avoid memory leaks when screens are closed.
2. **Coroutine Suspension Hangs:** Removed redundant `join()` calls on infinite hot flows in `init` blocks across multiple ViewModels and composables.
3. **Main-Thread Blocking:** Replaced `runBlocking` calls with `viewModelScope.launch` blocks.
4. **Parallel Search Scope:** Wrapped parallel searches in `supervisorScope` to prevent VM scope cancellation on individual query failures.