### PR TITLE
feat(desktop): build .deb for Debian/Ubuntu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,7 +307,8 @@ Before implementing code, researching code, or answering technical questions, th
 ### Desktop
 - **Windows**: `.msi` installer
 - **macOS**: `.dmg` (ARM and x86-64)
-- **Linux**: `.AppImage` (DEB and RPM removed post-1.0.4)
+- **Linux**: `.AppImage` (portable, all distros) + `.deb` (Debian/Ubuntu, via jpackage `TargetFormat.Deb`). RPM removed post-1.0.4.
+  - Build the `.deb`: `./gradlew :composeApp:vlcSetup --no-configuration-cache` (once, to fetch VLC natives) → `./gradlew :desktopApp:packageDeb --no-configuration-cache`. Output: `desktopApp/build/compose/binaries/main/deb/simpmusic_<version>_amd64.deb`. Use `packageReleaseDeb` for a ProGuard-shrunk (smaller) build.
 
 ## 🚨 Important Notes
 
@@ -448,7 +449,8 @@ if (getPlatform() == Platform.Android) {
 
 ### Architecture Changes
 - **Desktop: GStreamer → VLCJ**: Completely replaced GStreamer with VLCJ for desktop audio playback
-- **DEB/RPM builds removed**: Desktop Linux now only ships AppImage
+- **DEB/RPM builds removed**: Desktop Linux shipped AppImage only (post-1.0.4)
+- **DEB build re-added (2026-07)**: `TargetFormat.Deb` added to `:desktopApp` `nativeDistributions` linux targets so jpackage produces `simpmusic_<version>_amd64.deb` for Debian/Ubuntu (menu entry + VLC natives + bundled JRE). RPM still not shipped.
 
 ### New Features (v1.0.4)
 - **Android Crossfade & DJ-style transition**: `CrossfadeExoPlayerAdapter` with auto mode (like AutoMix)
@@ -497,6 +499,6 @@ After completing any of the following types of changes, the AI agent **MUST** up
 
 *This document helps AI Agents quickly understand the SimpMusic project. Update regularly when there are major changes to architecture or structure.*
 
-**Last updated**: 2026-03-14
+**Last updated**: 2026-07-03
 **Project version**: Check latest release on GitHub
 **Maintained by**: maxrave-dev and contributors

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -171,8 +171,11 @@ compose.desktop {
                     listOf(TargetFormat.Dmg, TargetFormat.Msi),
                 )
             } else {
+                // Linux host: Deb is the primary native installer for Debian/
+                // Ubuntu users (jpackage builds it via dpkg-deb + fakeroot).
+                // AppImage stays for the "one-for-all-distros" portable build.
                 listTarget.addAll(
-                    listOf(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.AppImage),
+                    listOf(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.AppImage, TargetFormat.Deb),
                 )
             }
             targetFormats(*listTarget.toTypedArray())
@@ -232,6 +235,13 @@ compose.desktop {
                         .get()
                         .removeSuffix("-hf")
                 iconFile.set(rootDir.resolve("composeApp/icon/circle_app_icon.png"))
+                // Debian package metadata — makes the generated .deb a proper
+                // desktop app: menu entry, category and maintainer for
+                // `dpkg -i` / apt install on Debian/Ubuntu.
+                debMaintainer = "maxrave-dev"
+                menuGroup = "SimpMusic"
+                appCategory = "Audio"
+                shortcut = true
             }
         }
 


### PR DESCRIPTION
Add TargetFormat.Deb to the Linux nativeDistributions targets in :desktopApp so jpackage produces simpmusic_<version>_amd64.deb, and enrich the linux{} block with Debian package metadata (maintainer, Audio category, menu group, shortcut) so the package installs as a proper desktop app with an application-menu entry and bundled VLC natives + JRE.

Update CLAUDE.md packaging docs and changelog accordingly.