### PR TITLE
Feat/queue button desktop miniplayer

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/MiniPlayer.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/MiniPlayer.kt
@@ -846,14 +846,9 @@ fun MiniPlayer(
                         Spacer(Modifier.width(4.dp))
                         // Queue Button
                         IconButton(
-                            modifier =
-                                Modifier
-                                    .width(32.dp)
-                                    .aspectRatio(1f)
-                                    .clip(CircleShape),
                             onClick = {
                                 showQueueBottomSheet = true
-                            },
+                            }
                         ) {
                             Icon(
                                 imageVector = Icons.AutoMirrored.Rounded.QueueMusic,

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/MiniPlayer.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/MiniPlayer.kt
@@ -42,6 +42,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.VolumeOff
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.filled.VolumeOff
 import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.material.icons.outlined.OpenInNew
@@ -111,6 +112,7 @@ import com.maxrave.simpmusic.ui.component.ExplicitBadge
 import com.maxrave.simpmusic.ui.component.HeartCheckBox
 import com.maxrave.simpmusic.ui.component.PlayPauseButton
 import com.maxrave.simpmusic.ui.component.PlayerControlLayout
+import com.maxrave.simpmusic.ui.component.QueueBottomSheet
 import com.maxrave.simpmusic.ui.component.liquidGlass
 import com.maxrave.simpmusic.ui.theme.LocalIsDarkTheme
 import com.maxrave.simpmusic.ui.theme.typo
@@ -216,6 +218,7 @@ fun MiniPlayer(
         remember {
             mutableStateOf(false)
         }
+
 
     val coroutineScope = rememberCoroutineScope()
 
@@ -566,6 +569,9 @@ fun MiniPlayer(
         var sliderValue by rememberSaveable {
             mutableFloatStateOf(0f)
         }
+        var showQueueBottomSheet by rememberSaveable {
+            mutableStateOf(false)
+        }
         LaunchedEffect(key1 = timelineState, key2 = isSliding) {
             if (!isSliding) {
                 sliderValue =
@@ -576,6 +582,15 @@ fun MiniPlayer(
                     }
             }
         }
+
+        if (showQueueBottomSheet) {
+            QueueBottomSheet(
+                onDismiss = {
+                    showQueueBottomSheet = false
+                },
+            )
+        }
+
         Box(
             modifier.then(
                 Modifier.clickable {
@@ -832,6 +847,24 @@ fun MiniPlayer(
                             sharedViewModel.onUIEvent(UIEvent.ToggleLike)
                         }
                         Spacer(Modifier.width(4.dp))
+                        // Queue Button
+                        IconButton(
+                            modifier =
+                                Modifier
+                                    .width(32.dp)
+                                    .aspectRatio(1f)
+                                    .clip(CircleShape),
+                            onClick = {
+                                showQueueBottomSheet = true
+                            },
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Rounded.QueueMusic,
+                                tint = Color.White,
+                                contentDescription = "",
+                            )
+                        }
+                        Spacer(Modifier.width(2.dp))
                         // Desktop mini player button (JVM only)
                         if (getPlatform() == Platform.Desktop) {
                             IconButton(onClick = { toggleMiniPlayer() }) {

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/MiniPlayer.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/MiniPlayer.kt
@@ -42,6 +42,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.VolumeOff
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.filled.VolumeOff
 import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.material.icons.outlined.OpenInNew
@@ -111,6 +112,7 @@ import com.maxrave.simpmusic.ui.component.ExplicitBadge
 import com.maxrave.simpmusic.ui.component.HeartCheckBox
 import com.maxrave.simpmusic.ui.component.PlayPauseButton
 import com.maxrave.simpmusic.ui.component.PlayerControlLayout
+import com.maxrave.simpmusic.ui.component.QueueBottomSheet
 import com.maxrave.simpmusic.ui.component.liquidGlass
 import com.maxrave.simpmusic.ui.theme.LocalIsDarkTheme
 import com.maxrave.simpmusic.ui.theme.typo
@@ -216,6 +218,7 @@ fun MiniPlayer(
         remember {
             mutableStateOf(false)
         }
+
 
     val coroutineScope = rememberCoroutineScope()
 
@@ -566,6 +569,9 @@ fun MiniPlayer(
         var sliderValue by rememberSaveable {
             mutableFloatStateOf(0f)
         }
+        var showQueueBottomSheet by rememberSaveable {
+            mutableStateOf(false)
+        }
         LaunchedEffect(key1 = timelineState, key2 = isSliding) {
             if (!isSliding) {
                 sliderValue =
@@ -575,6 +581,13 @@ fun MiniPlayer(
                         0f
                     }
             }
+        }
+        if (showQueueBottomSheet) {
+            QueueBottomSheet(
+                onDismiss = {
+                    showQueueBottomSheet = false
+                },
+            )
         }
         Box(
             modifier.then(
@@ -832,6 +845,24 @@ fun MiniPlayer(
                             sharedViewModel.onUIEvent(UIEvent.ToggleLike)
                         }
                         Spacer(Modifier.width(4.dp))
+                        // Queue Button
+                        IconButton(
+                            modifier =
+                                Modifier
+                                    .width(32.dp)
+                                    .aspectRatio(1f)
+                                    .clip(CircleShape),
+                            onClick = {
+                                showQueueBottomSheet = true
+                            },
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Rounded.QueueMusic,
+                                tint = Color.White,
+                                contentDescription = "",
+                            )
+                        }
+                        Spacer(Modifier.width(2.dp))
                         // Desktop mini player button (JVM only)
                         if (getPlatform() == Platform.Desktop) {
                             IconButton(onClick = { toggleMiniPlayer() }) {


### PR DESCRIPTION
Hi,

I saw for the update you could now see the queue button, but that currently only exists on the Now Playing tab. Originally I couldn't find it and assumed it was an android feature. So I think adding the queue button to the persistent minibar is a helpful change, and its similar to other apps like Spotify that most people are familiar with.

TLDR: Add queue button to desktop mini player

Video of Implementation

https://github.com/user-attachments/assets/d812f71b-2f2c-4772-94c4-afab2e37e6c3

