### PR TITLE
Fix/Make only one instance of a song have the playing icon

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
@@ -927,6 +927,11 @@ fun QueueBottomSheet(
             queueData?.data?.listTracks ?: emptyList()
         }
     }
+    val currentSongIndex by remember(queue, songEntity) {
+        derivedStateOf {
+            musicServiceHandler.currentOrderIndex().takeIf { it > -1 } ?: 0
+        }
+    }
     val loadMoreState by remember {
         derivedStateOf {
             queueData?.queueState ?: QueueData.StateSource.STATE_CREATED
@@ -1167,7 +1172,7 @@ fun QueueBottomSheet(
                             ) { _ ->
                                 SongFullWidthItems(
                                     track = track,
-                                    isPlaying = track.videoId == songEntity?.videoId,
+                                    isPlaying = index == currentSongIndex,
                                     modifier =
                                         Modifier
                                             .fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
@@ -927,11 +927,7 @@ fun QueueBottomSheet(
             queueData?.data?.listTracks ?: emptyList()
         }
     }
-    val currentSongIndex by remember(queue, songEntity) {
-        derivedStateOf {
-            musicServiceHandler.currentOrderIndex().takeIf { it > -1 } ?: 0
-        }
-    }
+    val currentSongIndex by musicServiceHandler.currentSongIndex.collectAsStateWithLifecycle()
     val loadMoreState by remember {
         derivedStateOf {
             queueData?.queueState ?: QueueData.StateSource.STATE_CREATED
@@ -1172,7 +1168,7 @@ fun QueueBottomSheet(
                             ) { _ ->
                                 SongFullWidthItems(
                                     track = track,
-                                    isPlaying = index == currentSongIndex,
+                                    isPlaying = index == currentSongIndex && track.videoId == songEntity?.videoId,
                                     modifier =
                                         Modifier
                                             .fillMaxWidth(),


### PR DESCRIPTION
Hi, when inside the queue tab, if you have multiple of the same song queued up, each instance of the song will display as currently playing - caused by `isPlaying = track.videoId == songEntity?.videoId,` 

Before the fix : 

https://github.com/user-attachments/assets/00c3d25c-3dbb-499b-b884-872edbc11b97



I fixed this by having tracking `currentSongIndex ` and changing isPlaying to `isPlaying = index == currentSongIndex`. 

After the fix: 

https://github.com/user-attachments/assets/44a4e8fa-5c91-4ba0-bef4-54488453db4e

Note: to demonstrate the bug, the recordings were taken on a build that features a playNext duplication fix [(maxrave-dev/core/pull/15)](https://github.com/maxrave-dev/core/pull/15) to consistently get duplicate tracks. This pull request is independent of the other, but was useful for testing.