### PR TITLE
feat: podcast improvements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "core"]
     path = core
-    url = https://github.com/maxrave-dev/core
+    url = https://github.com/RadNotRed/core

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "core"]
     path = core
-    url = https://github.com/RadNotRed/core
+    url = https://github.com/maxrave-dev/core

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -592,4 +592,7 @@
     <string name="import_result_skipped">%1$d entries were skipped because their song was missing from the file.</string>
     <string name="import_failed">Import failed</string>
     <string name="import_invalid_file">This file is not a valid SimpMusic import file. Convert your library at simpmusic.org first.</string>
+    <string name="download_all_episodes">Download all episodes</string>
+    <string name="save_episode_offline">Save episode offline</string>
+    <string name="resume_at">Resume at %1$s</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -595,4 +595,7 @@
     <string name="download_all_episodes">Download all episodes</string>
     <string name="save_episode_offline">Save episode offline</string>
     <string name="resume_at">Resume at %1$s</string>
+    <string name="podcast_rewind_interval">Podcast rewind interval</string>
+    <string name="podcast_forward_interval">Podcast forward interval</string>
+    <string name="podcast_seek_interval_description">Choose how many seconds the podcast control skips.</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/di/ViewModelModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/di/ViewModelModule.kt
@@ -117,6 +117,9 @@ val viewModelModule =
         viewModel {
             PodcastViewModel(
                 get(),
+                get(),
+                get(),
+                get(),
             )
         }
         viewModel {

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
@@ -246,6 +246,7 @@ import simpmusic.composeapp.generated.resources.processing
 import simpmusic.composeapp.generated.resources.queue
 import simpmusic.composeapp.generated.resources.radio
 import simpmusic.composeapp.generated.resources.save
+import simpmusic.composeapp.generated.resources.save_episode_offline
 import simpmusic.composeapp.generated.resources.save_to_local_playlist
 import simpmusic.composeapp.generated.resources.saved_to_local_playlist
 import simpmusic.composeapp.generated.resources.scale
@@ -1391,6 +1392,7 @@ fun NowPlayingBottomSheet(
     dataStoreManager: DataStoreManager = koinInject<DataStoreManager>(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val isPodcast = uiState.songUIState.isPodcast
     val coroutineScope = rememberCoroutineScope()
     val modelBottomSheetState =
         rememberModalBottomSheetState(
@@ -1733,13 +1735,15 @@ fun NowPlayingBottomSheet(
                             }
                         }
                     }
-                    CheckBoxActionButton(
-                        defaultChecked = uiState.songUIState.liked,
-                        isHeartIcon = true,
-                        onChangeListener = {
-                            viewModel.onUIEvent(NowPlayingBottomSheetUIEvent.ToggleLike)
-                        },
-                    )
+                    if (!isPodcast) {
+                        CheckBoxActionButton(
+                            defaultChecked = uiState.songUIState.liked,
+                            isHeartIcon = true,
+                            onChangeListener = {
+                                viewModel.onUIEvent(NowPlayingBottomSheetUIEvent.ToggleLike)
+                            },
+                        )
+                    }
                     ActionButton(
                         icon =
                             when (uiState.songUIState.downloadState) {
@@ -1759,21 +1763,24 @@ fun NowPlayingBottomSheet(
                             },
                         text =
                             when (uiState.songUIState.downloadState) {
-                                DownloadState.STATE_NOT_DOWNLOADED -> Res.string.download
+                                DownloadState.STATE_NOT_DOWNLOADED ->
+                                    if (isPodcast) Res.string.save_episode_offline else Res.string.download
                                 DownloadState.STATE_DOWNLOADING -> Res.string.downloading
                                 DownloadState.STATE_DOWNLOADED -> Res.string.downloaded
                                 DownloadState.STATE_PREPARING -> Res.string.downloading
-                                else -> Res.string.download
+                                else -> if (isPodcast) Res.string.save_episode_offline else Res.string.download
                             },
                     ) {
                         viewModel.onUIEvent(NowPlayingBottomSheetUIEvent.Download)
                     }
-                    ActionButton(
-                        icon = SimpIcons.PlaylistAdd,
-                        text = Res.string.add_to_a_playlist,
-                    ) {
-                        viewModel.resetPlaylists()
-                        addToAPlaylist = true
+                    if (!isPodcast) {
+                        ActionButton(
+                            icon = SimpIcons.PlaylistAdd,
+                            text = Res.string.add_to_a_playlist,
+                        ) {
+                            viewModel.resetPlaylists()
+                            addToAPlaylist = true
+                        }
                     }
                     ActionButton(
                         icon = SimpIcons.PlayCircle,
@@ -1793,8 +1800,9 @@ fun NowPlayingBottomSheet(
                     ) {
                         artist = true
                     }
-                    ActionButton(
-                        icon = SimpIcons.Album,
+                    if (!isPodcast) {
+                        ActionButton(
+                            icon = SimpIcons.Album,
                         // Three states, not two. A track can carry an album ID with no title: the
                         // row it was parsed from links an album but never spells its name out.
                         // That case still navigates, so it must not read "No album" — but the name
@@ -1802,39 +1810,40 @@ fun NowPlayingBottomSheet(
                         // showing a blank row. The parser deliberately leaves the name empty
                         // instead of inventing one, because a made-up title would travel out to
                         // MediaSession and into external scrobblers.
-                        text =
-                            when {
-                                uiState.songUIState.album == null -> Res.string.no_album
-                                uiState.songUIState.album?.name.isNullOrBlank() -> Res.string.album
-                                else -> null
-                            },
-                        textString = uiState.songUIState.album?.name?.takeIf { it.isNotBlank() },
-                        enable = uiState.songUIState.album != null,
-                    ) {
-                        uiState.songUIState.album?.id?.let { id ->
-                            onNavigateToOtherScreen()
-                            navController.navigate(AlbumDestination(browseId = id))
+                            text =
+                                when {
+                                    uiState.songUIState.album == null -> Res.string.no_album
+                                    uiState.songUIState.album?.name.isNullOrBlank() -> Res.string.album
+                                    else -> null
+                                },
+                            textString = uiState.songUIState.album?.name?.takeIf { it.isNotBlank() },
+                            enable = uiState.songUIState.album != null,
+                        ) {
+                            uiState.songUIState.album?.id?.let { id ->
+                                onNavigateToOtherScreen()
+                                navController.navigate(AlbumDestination(browseId = id))
+                            }
                         }
-                    }
-                    ActionButton(
-                        icon = SimpIcons.Sensors,
-                        text = Res.string.start_radio,
-                    ) {
-                        viewModel.onUIEvent(
-                            NowPlayingBottomSheetUIEvent.StartRadio(
-                                videoId = uiState.songUIState.videoId,
-                                name = "\"${uiState.songUIState.title}\" ${runBlocking { getString(Res.string.radio) }}",
-                            ),
-                        )
-                        hideModalBottomSheet()
-                    }
-                    Crossfade(targetState = changeMainLyricsProviderEnable) {
-                        if (it) {
-                            ActionButton(
-                                icon = SimpIcons.Lyrics,
-                                text = Res.string.main_lyrics_provider,
-                            ) {
-                                mainLyricsProvider = true
+                        ActionButton(
+                            icon = SimpIcons.Sensors,
+                            text = Res.string.start_radio,
+                        ) {
+                            viewModel.onUIEvent(
+                                NowPlayingBottomSheetUIEvent.StartRadio(
+                                    videoId = uiState.songUIState.videoId,
+                                    name = "\"${uiState.songUIState.title}\" ${runBlocking { getString(Res.string.radio) }}",
+                                ),
+                            )
+                            hideModalBottomSheet()
+                        }
+                        Crossfade(targetState = changeMainLyricsProviderEnable) {
+                            if (it) {
+                                ActionButton(
+                                    icon = SimpIcons.Lyrics,
+                                    text = Res.string.main_lyrics_provider,
+                                ) {
+                                    mainLyricsProvider = true
+                                }
                             }
                         }
                     }
@@ -1877,12 +1886,12 @@ fun NowPlayingBottomSheet(
                             ActionButton(
                                 icon = SimpIcons.Speed,
                                 text =
-                                    if (crossfadeEnabled != DataStoreManager.TRUE) {
+                                    if (isPodcast || crossfadeEnabled != DataStoreManager.TRUE) {
                                         if (isDesktop) Res.string.playback_speed else Res.string.playback_speed_pitch
                                     } else {
                                         Res.string.playback_speed_pitch_disabled
                                     },
-                                enable = crossfadeEnabled != DataStoreManager.TRUE,
+                                enable = isPodcast || crossfadeEnabled != DataStoreManager.TRUE,
                             ) {
                                 changePlaybackSpeedPitch = true
                             }

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
@@ -1426,8 +1426,12 @@ fun NowPlayingBottomSheet(
     }
 
     if (changePlaybackSpeedPitch) {
-        val playbackSpeed by dataStoreManager.playbackSpeed.collectAsState(1f)
-        val pitch by dataStoreManager.pitch.collectAsState(0)
+        val playbackSpeed by
+            (if (isPodcast) dataStoreManager.podcastPlaybackSpeed else dataStoreManager.playbackSpeed)
+                .collectAsState(1f)
+        val pitch by
+            (if (isPodcast) dataStoreManager.podcastPitch else dataStoreManager.pitch)
+                .collectAsState(0)
         PlaybackSpeedPitchBottomSheet(
             onDismiss = { changePlaybackSpeedPitch = false },
             playbackSpeed = playbackSpeed,

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/PlayerControlLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/PlayerControlLayout.kt
@@ -13,20 +13,22 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.maxrave.domain.mediaservice.handler.ControlState
 import com.maxrave.domain.mediaservice.handler.RepeatState
 import com.maxrave.simpmusic.ui.icon.PauseCircle
 import com.maxrave.simpmusic.ui.icon.PlayCircle
-import com.maxrave.simpmusic.ui.icon.Forward5
 import com.maxrave.simpmusic.ui.icon.Repeat
 import com.maxrave.simpmusic.ui.icon.RepeatOne
-import com.maxrave.simpmusic.ui.icon.Replay5
 import com.maxrave.simpmusic.ui.icon.Shuffle
 import com.maxrave.simpmusic.ui.icon.SimpIcons
 import com.maxrave.simpmusic.ui.icon.SkipNext
@@ -39,6 +41,8 @@ fun PlayerControlLayout(
     controllerState: ControlState,
     isSmallSize: Boolean = false,
     isPodcast: Boolean = false,
+    podcastRewindSeconds: Int = 5,
+    podcastForwardSeconds: Int = 5,
     contentColor: Color = Color.White,
     onUIEvent: (UIEvent) -> Unit,
 ) {
@@ -105,19 +109,31 @@ fun PlayerControlLayout(
                         )
                         .clickable {
                             if (isPodcast) {
-                                onUIEvent(UIEvent.Backward)
+                                onUIEvent(UIEvent.SeekBy(-podcastRewindSeconds * 1_000L))
                             } else if (controllerState.isPreviousAvailable) {
                                 onUIEvent(UIEvent.Previous)
                             }
                         },
                 contentAlignment = Alignment.Center,
             ) {
-                Icon(
-                    imageVector = if (isPodcast) SimpIcons.Replay5 else SimpIcons.SkipPrevious,
-                    tint = if (isPodcast || controllerState.isPreviousAvailable) contentColor else contentColor.copy(alpha = 0.4f),
-                    contentDescription = if (isPodcast) "Back 5 seconds" else "Previous",
-                    modifier = Modifier.size(mediumIcon.first),
-                )
+                if (isPodcast) {
+                    Text(
+                        text = "-$podcastRewindSeconds",
+                        color = contentColor,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier =
+                            Modifier.semantics {
+                                contentDescription = "Back $podcastRewindSeconds seconds"
+                            },
+                    )
+                } else {
+                    Icon(
+                        imageVector = SimpIcons.SkipPrevious,
+                        tint = if (controllerState.isPreviousAvailable) contentColor else contentColor.copy(alpha = 0.4f),
+                        contentDescription = "Previous",
+                        modifier = Modifier.size(mediumIcon.first),
+                    )
+                }
             }
         }
         Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
@@ -166,19 +182,31 @@ fun PlayerControlLayout(
                         )
                         .clickable {
                             if (isPodcast) {
-                                onUIEvent(UIEvent.Forward)
+                                onUIEvent(UIEvent.SeekBy(podcastForwardSeconds * 1_000L))
                             } else if (controllerState.isNextAvailable) {
                                 onUIEvent(UIEvent.Next)
                             }
                         },
                 contentAlignment = Alignment.Center,
             ) {
-                Icon(
-                    imageVector = if (isPodcast) SimpIcons.Forward5 else SimpIcons.SkipNext,
-                    tint = if (isPodcast || controllerState.isNextAvailable) contentColor else contentColor.copy(alpha = 0.4f),
-                    contentDescription = if (isPodcast) "Forward 5 seconds" else "Next",
-                    modifier = Modifier.size(mediumIcon.first),
-                )
+                if (isPodcast) {
+                    Text(
+                        text = "+$podcastForwardSeconds",
+                        color = contentColor,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier =
+                            Modifier.semantics {
+                                contentDescription = "Forward $podcastForwardSeconds seconds"
+                            },
+                    )
+                } else {
+                    Icon(
+                        imageVector = SimpIcons.SkipNext,
+                        tint = if (controllerState.isNextAvailable) contentColor else contentColor.copy(alpha = 0.4f),
+                        contentDescription = "Next",
+                        modifier = Modifier.size(mediumIcon.first),
+                    )
+                }
             }
         }
         Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/PlayerControlLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/PlayerControlLayout.kt
@@ -23,8 +23,10 @@ import com.maxrave.domain.mediaservice.handler.ControlState
 import com.maxrave.domain.mediaservice.handler.RepeatState
 import com.maxrave.simpmusic.ui.icon.PauseCircle
 import com.maxrave.simpmusic.ui.icon.PlayCircle
+import com.maxrave.simpmusic.ui.icon.Forward5
 import com.maxrave.simpmusic.ui.icon.Repeat
 import com.maxrave.simpmusic.ui.icon.RepeatOne
+import com.maxrave.simpmusic.ui.icon.Replay5
 import com.maxrave.simpmusic.ui.icon.Shuffle
 import com.maxrave.simpmusic.ui.icon.SimpIcons
 import com.maxrave.simpmusic.ui.icon.SkipNext
@@ -36,6 +38,7 @@ import com.maxrave.simpmusic.viewModel.UIEvent
 fun PlayerControlLayout(
     controllerState: ControlState,
     isSmallSize: Boolean = false,
+    isPodcast: Boolean = false,
     contentColor: Color = Color.White,
     onUIEvent: (UIEvent) -> Unit,
 ) {
@@ -63,23 +66,27 @@ fun PlayerControlLayout(
                             CircleShape,
                         )
                         .clickable {
-                            onUIEvent(UIEvent.Shuffle)
+                            if (isPodcast) {
+                                if (controllerState.isPreviousAvailable) onUIEvent(UIEvent.Previous)
+                            } else {
+                                onUIEvent(UIEvent.Shuffle)
+                            }
                         },
                 contentAlignment = Alignment.Center,
             ) {
-                Crossfade(targetState = controllerState.isShuffle, label = "Shuffle Button") { isShuffle ->
-                    if (!isShuffle) {
+                if (isPodcast) {
+                    Icon(
+                        imageVector = SimpIcons.SkipPrevious,
+                        tint = if (controllerState.isPreviousAvailable) contentColor else contentColor.copy(alpha = 0.4f),
+                        contentDescription = "Previous episode",
+                        modifier = Modifier.size(smallIcon.first),
+                    )
+                } else {
+                    Crossfade(targetState = controllerState.isShuffle, label = "Shuffle Button") { isShuffle ->
                         Icon(
                             imageVector = SimpIcons.Shuffle,
-                            tint = contentColor,
-                            contentDescription = "",
-                            modifier = Modifier.size(smallIcon.first),
-                        )
-                    } else {
-                        Icon(
-                            imageVector = SimpIcons.Shuffle,
-                            tint = seed,
-                            contentDescription = "",
+                            tint = if (isShuffle) seed else contentColor,
+                            contentDescription = "Shuffle",
                             modifier = Modifier.size(smallIcon.first),
                         )
                     }
@@ -97,16 +104,18 @@ fun PlayerControlLayout(
                             CircleShape,
                         )
                         .clickable {
-                            if (controllerState.isPreviousAvailable) {
+                            if (isPodcast) {
+                                onUIEvent(UIEvent.Backward)
+                            } else if (controllerState.isPreviousAvailable) {
                                 onUIEvent(UIEvent.Previous)
                             }
                         },
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
-                    imageVector = SimpIcons.SkipPrevious,
-                    tint = if (controllerState.isPreviousAvailable) contentColor else contentColor.copy(alpha = 0.4f),
-                    contentDescription = "",
+                    imageVector = if (isPodcast) SimpIcons.Replay5 else SimpIcons.SkipPrevious,
+                    tint = if (isPodcast || controllerState.isPreviousAvailable) contentColor else contentColor.copy(alpha = 0.4f),
+                    contentDescription = if (isPodcast) "Back 5 seconds" else "Previous",
                     modifier = Modifier.size(mediumIcon.first),
                 )
             }
@@ -156,16 +165,18 @@ fun PlayerControlLayout(
                             CircleShape,
                         )
                         .clickable {
-                            if (controllerState.isNextAvailable) {
+                            if (isPodcast) {
+                                onUIEvent(UIEvent.Forward)
+                            } else if (controllerState.isNextAvailable) {
                                 onUIEvent(UIEvent.Next)
                             }
                         },
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
-                    imageVector = SimpIcons.SkipNext,
-                    tint = if (controllerState.isNextAvailable) contentColor else contentColor.copy(alpha = 0.4f),
-                    contentDescription = "",
+                    imageVector = if (isPodcast) SimpIcons.Forward5 else SimpIcons.SkipNext,
+                    tint = if (isPodcast || controllerState.isNextAvailable) contentColor else contentColor.copy(alpha = 0.4f),
+                    contentDescription = if (isPodcast) "Forward 5 seconds" else "Next",
                     modifier = Modifier.size(mediumIcon.first),
                 )
             }
@@ -180,37 +191,50 @@ fun PlayerControlLayout(
                             CircleShape,
                         )
                         .clickable {
-                            onUIEvent(UIEvent.Repeat)
+                            if (isPodcast) {
+                                if (controllerState.isNextAvailable) onUIEvent(UIEvent.Next)
+                            } else {
+                                onUIEvent(UIEvent.Repeat)
+                            }
                         },
                 contentAlignment = Alignment.Center,
             ) {
-                Crossfade(targetState = controllerState.repeatState) { rs ->
-                    when (rs) {
-                        is RepeatState.None -> {
-                            Icon(
-                                imageVector = SimpIcons.Repeat,
-                                tint = contentColor,
-                                contentDescription = "",
-                                modifier = Modifier.size(smallIcon.first),
-                            )
-                        }
+                if (isPodcast) {
+                    Icon(
+                        imageVector = SimpIcons.SkipNext,
+                        tint = if (controllerState.isNextAvailable) contentColor else contentColor.copy(alpha = 0.4f),
+                        contentDescription = "Next episode",
+                        modifier = Modifier.size(smallIcon.first),
+                    )
+                } else {
+                    Crossfade(targetState = controllerState.repeatState) { rs ->
+                        when (rs) {
+                            is RepeatState.None -> {
+                                Icon(
+                                    imageVector = SimpIcons.Repeat,
+                                    tint = contentColor,
+                                    contentDescription = "Repeat",
+                                    modifier = Modifier.size(smallIcon.first),
+                                )
+                            }
 
-                        RepeatState.All -> {
-                            Icon(
-                                imageVector = SimpIcons.Repeat,
-                                tint = seed,
-                                contentDescription = "",
-                                modifier = Modifier.size(smallIcon.first),
-                            )
-                        }
+                            RepeatState.All -> {
+                                Icon(
+                                    imageVector = SimpIcons.Repeat,
+                                    tint = seed,
+                                    contentDescription = "Repeat all",
+                                    modifier = Modifier.size(smallIcon.first),
+                                )
+                            }
 
-                        RepeatState.One -> {
-                            Icon(
-                                imageVector = SimpIcons.RepeatOne,
-                                tint = seed,
-                                contentDescription = "",
-                                modifier = Modifier.size(smallIcon.first),
-                            )
+                            RepeatState.One -> {
+                                Icon(
+                                    imageVector = SimpIcons.RepeatOne,
+                                    tint = seed,
+                                    contentDescription = "Repeat one",
+                                    modifier = Modifier.size(smallIcon.first),
+                                )
+                            }
                         }
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/PlayerControlLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/PlayerControlLayout.kt
@@ -69,7 +69,7 @@ fun PlayerControlLayout(
                         .clip(
                             CircleShape,
                         )
-                        .clickable {
+                        .clickable(enabled = !isPodcast || controllerState.isPreviousAvailable) {
                             if (isPodcast) {
                                 if (controllerState.isPreviousAvailable) onUIEvent(UIEvent.Previous)
                             } else {
@@ -107,7 +107,7 @@ fun PlayerControlLayout(
                         .clip(
                             CircleShape,
                         )
-                        .clickable {
+                        .clickable(enabled = isPodcast || controllerState.isPreviousAvailable) {
                             if (isPodcast) {
                                 onUIEvent(UIEvent.SeekBy(-podcastRewindSeconds * 1_000L))
                             } else if (controllerState.isPreviousAvailable) {
@@ -180,7 +180,7 @@ fun PlayerControlLayout(
                         .clip(
                             CircleShape,
                         )
-                        .clickable {
+                        .clickable(enabled = isPodcast || controllerState.isNextAvailable) {
                             if (isPodcast) {
                                 onUIEvent(UIEvent.SeekBy(podcastForwardSeconds * 1_000L))
                             } else if (controllerState.isNextAvailable) {
@@ -218,7 +218,7 @@ fun PlayerControlLayout(
                         .clip(
                             CircleShape,
                         )
-                        .clickable {
+                        .clickable(enabled = !isPodcast || controllerState.isNextAvailable) {
                             if (isPodcast) {
                                 if (controllerState.isNextAvailable) onUIEvent(UIEvent.Next)
                             } else {

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/PodcastEpisodeItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/PodcastEpisodeItem.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -47,6 +48,10 @@ fun PodcastEpisodeFullWidthItem(
     onClick: (String) -> Unit,
     onMoreClickListener: (() -> Unit)? = null,
 ) {
+    val durationMs =
+        remember(episode.durationString) {
+            episode.durationString?.let(::parseTimestampToMilliseconds)?.toLong() ?: 0L
+        }
     Box(
         modifier =
             modifier
@@ -119,7 +124,6 @@ fun PodcastEpisodeFullWidthItem(
                         color = MaterialTheme.colorScheme.primary,
                         maxLines = 1,
                     )
-                    val durationMs = episode.durationString?.let(::parseTimestampToMilliseconds)?.toLong() ?: 0L
                     if (durationMs > 0L) {
                         LinearProgressIndicator(
                             progress = { (progressMs.toFloat() / durationMs).coerceIn(0f, 1f) },

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/PodcastEpisodeItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/PodcastEpisodeItem.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -28,16 +29,21 @@ import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.maxrave.domain.data.model.podcast.PodcastBrowse
+import com.maxrave.simpmusic.extension.formatDuration
+import com.maxrave.simpmusic.extension.parseTimestampToMilliseconds
 import com.maxrave.simpmusic.ui.icon.MoreVert
 import com.maxrave.simpmusic.ui.icon.SimpIcons
 import com.maxrave.simpmusic.ui.theme.typo
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
 import simpmusic.composeapp.generated.resources.Res
+import simpmusic.composeapp.generated.resources.resume_at
 
 @Composable
 fun PodcastEpisodeFullWidthItem(
     modifier: Modifier = Modifier,
     episode: PodcastBrowse.EpisodeItem,
+    progressMs: Long = 0L,
     onClick: (String) -> Unit,
     onMoreClickListener: (() -> Unit)? = null,
 ) {
@@ -105,6 +111,22 @@ fun PodcastEpisodeFullWidthItem(
                                 animationMode = MarqueeAnimationMode.Immediately,
                             ).focusable(),
                 )
+
+                if (progressMs >= 5_000L) {
+                    Text(
+                        text = stringResource(Res.string.resume_at, formatDuration(progressMs)),
+                        style = typo().bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                    )
+                    val durationMs = episode.durationString?.let(::parseTimestampToMilliseconds)?.toLong() ?: 0L
+                    if (durationMs > 0L) {
+                        LinearProgressIndicator(
+                            progress = { (progressMs.toFloat() / durationMs).coerceIn(0f, 1f) },
+                            modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+                        )
+                    }
+                }
 
                 val description = episode.description
                 if (description != null) {

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/RippleIconButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/RippleIconButton.kt
@@ -19,6 +19,7 @@ fun RippleIconButton(
     modifier: Modifier = Modifier,
     fillMaxSize: Boolean = false,
     tint: Color = Color.White,
+    contentDescription: String? = null,
     onClick: () -> Unit,
 ) {
     IconButton(
@@ -27,7 +28,7 @@ fun RippleIconButton(
     ) {
         Icon(
             imageVector,
-            null,
+            contentDescription,
             tint = tint,
             modifier = if (fillMaxSize) Modifier.fillMaxSize().padding(4.dp) else Modifier,
         )

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/MiniPlayer.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/MiniPlayer.kt
@@ -97,6 +97,7 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.kmpalette.rememberPaletteState
 import com.maxrave.domain.data.entities.SongEntity
+import com.maxrave.domain.extension.isPodcast
 import com.maxrave.domain.manager.DataStoreManager
 import com.maxrave.domain.utils.connectArtists
 import com.maxrave.logger.Logger
@@ -718,6 +719,7 @@ fun MiniPlayer(
                             PlayerControlLayout(
                                 controllerState,
                                 isSmallSize = true,
+                                isPodcast = songEntity?.isPodcast() == true,
                                 contentColor = textColor,
                             ) {
                                 sharedViewModel.onUIEvent(it)

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/MiniPlayer.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/MiniPlayer.kt
@@ -155,6 +155,8 @@ fun MiniPlayer(
     val isLiquidGlassEnabled by sharedViewModel.getEnableLiquidGlass().collectAsStateWithLifecycle(DataStoreManager.FALSE)
     val controllerState by sharedViewModel.controllerState.collectAsStateWithLifecycle()
     val timelineState by sharedViewModel.timeline.collectAsStateWithLifecycle()
+    val podcastRewindSeconds by sharedViewModel.podcastRewindSeconds.collectAsStateWithLifecycle()
+    val podcastForwardSeconds by sharedViewModel.podcastForwardSeconds.collectAsStateWithLifecycle()
 
     val layer = rememberGraphicsLayer()
     val luminanceAnimation = remember { Animatable(0f) }
@@ -720,6 +722,8 @@ fun MiniPlayer(
                                 controllerState,
                                 isSmallSize = true,
                                 isPodcast = songEntity?.isPodcast() == true,
+                                podcastRewindSeconds = podcastRewindSeconds,
+                                podcastForwardSeconds = podcastForwardSeconds,
                                 contentColor = textColor,
                             ) {
                                 sharedViewModel.onUIEvent(it)

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/home/SettingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/home/SettingScreen.kt
@@ -310,6 +310,9 @@ import simpmusic.composeapp.generated.resources.proxy_port_message
 import simpmusic.composeapp.generated.resources.proxy_type
 import simpmusic.composeapp.generated.resources.proxy_username
 import simpmusic.composeapp.generated.resources.proxy_username_message
+import simpmusic.composeapp.generated.resources.podcast_forward_interval
+import simpmusic.composeapp.generated.resources.podcast_rewind_interval
+import simpmusic.composeapp.generated.resources.podcast_seek_interval_description
 import simpmusic.composeapp.generated.resources.quality
 import simpmusic.composeapp.generated.resources.restore_your_data
 import simpmusic.composeapp.generated.resources.restore_your_saved_data
@@ -516,6 +519,8 @@ fun SettingScreen(
     val crossfadeEnabled by viewModel.crossfadeEnabled.collectAsStateWithLifecycle()
     val crossfadeDuration by viewModel.crossfadeDuration.collectAsStateWithLifecycle()
     val crossfadeDjMode by viewModel.crossfadeDjMode.collectAsStateWithLifecycle()
+    val podcastRewindSeconds by viewModel.podcastRewindSeconds.collectAsStateWithLifecycle()
+    val podcastForwardSeconds by viewModel.podcastForwardSeconds.collectAsStateWithLifecycle()
     val castState by viewModel.castState.collectAsStateWithLifecycle()
 
     val isCheckingUpdate by sharedViewModel.isCheckingUpdate.collectAsStateWithLifecycle()
@@ -1094,6 +1099,62 @@ fun SettingScreen(
                     title = stringResource(Res.string.save_last_played),
                     subtitle = stringResource(Res.string.save_last_played_track_and_queue),
                     switch = (saveLastPlayed to { viewModel.setSaveLastPlayed(it) }),
+                )
+                SettingItem(
+                    title = stringResource(Res.string.podcast_rewind_interval),
+                    subtitle = "${podcastRewindSeconds}s · ${stringResource(Res.string.podcast_seek_interval_description)}",
+                    smallSubtitle = true,
+                    onClick = {
+                        viewModel.setAlertData(
+                            SettingAlertState(
+                                title = runBlocking { getString(Res.string.podcast_rewind_interval) },
+                                selectOne =
+                                    SettingAlertState.SelectData(
+                                        listSelect =
+                                            DataStoreManager.PODCAST_SEEK_INTERVALS.map { seconds ->
+                                                (podcastRewindSeconds == seconds) to "${seconds}s"
+                                            },
+                                    ),
+                                confirm =
+                                    runBlocking { getString(Res.string.change) } to { state ->
+                                        state.selectOne
+                                            ?.getSelected()
+                                            ?.removeSuffix("s")
+                                            ?.toIntOrNull()
+                                            ?.let { viewModel.setPodcastRewindSeconds(it) }
+                                    },
+                                dismiss = runBlocking { getString(Res.string.cancel) },
+                            ),
+                        )
+                    },
+                )
+                SettingItem(
+                    title = stringResource(Res.string.podcast_forward_interval),
+                    subtitle = "${podcastForwardSeconds}s · ${stringResource(Res.string.podcast_seek_interval_description)}",
+                    smallSubtitle = true,
+                    onClick = {
+                        viewModel.setAlertData(
+                            SettingAlertState(
+                                title = runBlocking { getString(Res.string.podcast_forward_interval) },
+                                selectOne =
+                                    SettingAlertState.SelectData(
+                                        listSelect =
+                                            DataStoreManager.PODCAST_SEEK_INTERVALS.map { seconds ->
+                                                (podcastForwardSeconds == seconds) to "${seconds}s"
+                                            },
+                                    ),
+                                confirm =
+                                    runBlocking { getString(Res.string.change) } to { state ->
+                                        state.selectOne
+                                            ?.getSelected()
+                                            ?.removeSuffix("s")
+                                            ?.toIntOrNull()
+                                            ?.let { viewModel.setPodcastForwardSeconds(it) }
+                                    },
+                                dismiss = runBlocking { getString(Res.string.cancel) },
+                            ),
+                        )
+                    },
                 )
                 if (getPlatform() == Platform.Android) {
                     SettingItem(

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/other/PodcastsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/other/PodcastsScreen.kt
@@ -120,7 +120,7 @@ fun PodcastScreen(
     }
     var shouldHideTopBar by rememberSaveable { mutableStateOf(false) }
 
-    var currentTrack by rememberSaveable {
+    var currentTrack by remember {
         mutableStateOf<Track?>(null)
     }
     var shouldShowMoreBottomSheet by rememberSaveable { mutableStateOf(false) }

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/other/PodcastsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/other/PodcastsScreen.kt
@@ -81,9 +81,9 @@ import com.maxrave.simpmusic.ui.component.NowPlayingBottomSheet
 import com.maxrave.simpmusic.ui.component.PodcastEpisodeFullWidthItem
 import com.maxrave.simpmusic.ui.component.RippleIconButton
 import com.maxrave.simpmusic.ui.icon.ArrowBackIosNew
+import com.maxrave.simpmusic.ui.icon.DownloadForOfflineOutlined
 import com.maxrave.simpmusic.ui.icon.PlayCircle
 import com.maxrave.simpmusic.ui.icon.Share
-import com.maxrave.simpmusic.ui.icon.Shuffle
 import com.maxrave.simpmusic.ui.icon.SimpIcons
 import com.maxrave.simpmusic.ui.navigation.destination.list.ArtistDestination
 import com.maxrave.simpmusic.ui.theme.typo
@@ -97,6 +97,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import simpmusic.composeapp.generated.resources.Res
 import simpmusic.composeapp.generated.resources.album_length
+import simpmusic.composeapp.generated.resources.download_all_episodes
 import simpmusic.composeapp.generated.resources.no_description
 import simpmusic.composeapp.generated.resources.podcasts
 
@@ -109,6 +110,7 @@ fun PodcastScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val isFavorite by viewModel.isFavorite.collectAsStateWithLifecycle()
+    val episodeProgress by viewModel.episodeProgress.collectAsStateWithLifecycle()
 
     val lazyState = rememberLazyListState()
     val firstItemVisible by remember {
@@ -340,13 +342,14 @@ fun PodcastScreen(
 
                                                 Spacer(Modifier.weight(1f))
 
-                                                // Shuffle
+                                                // Save every episode for offline playback.
                                                 RippleIconButton(
                                                     modifier = Modifier.size(36.dp),
-                                                    imageVector = SimpIcons.Shuffle,
+                                                    imageVector = SimpIcons.DownloadForOfflineOutlined,
                                                     fillMaxSize = true,
+                                                    contentDescription = stringResource(Res.string.download_all_episodes),
                                                 ) {
-                                                    viewModel.onUIEvent(PodcastUIEvent.Shuffle(id))
+                                                    viewModel.onUIEvent(PodcastUIEvent.DownloadAll)
                                                 }
 
                                                 Spacer(Modifier.size(5.dp))
@@ -400,6 +403,7 @@ fun PodcastScreen(
                         if (episode != null) {
                             PodcastEpisodeFullWidthItem(
                                 episode = episode,
+                                progressMs = episodeProgress[episode.videoId] ?: 0L,
                                 onClick = {
                                     viewModel.onUIEvent(
                                         PodcastUIEvent.EpisodeClick(

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/player/NowPlayingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/player/NowPlayingScreen.kt
@@ -297,6 +297,8 @@ fun NowPlayingScreenContent(
     val controllerState by sharedViewModel.controllerState.collectAsStateWithLifecycle()
     val screenDataState by sharedViewModel.nowPlayingScreenData.collectAsStateWithLifecycle()
     val timelineState by sharedViewModel.timeline.collectAsStateWithLifecycle()
+    val podcastRewindSeconds by sharedViewModel.podcastRewindSeconds.collectAsStateWithLifecycle()
+    val podcastForwardSeconds by sharedViewModel.podcastForwardSeconds.collectAsStateWithLifecycle()
     val likeStatus by sharedViewModel.likeStatus.collectAsStateWithLifecycle()
     val castState by sharedViewModel.castState.collectAsStateWithLifecycle()
 
@@ -1805,6 +1807,8 @@ fun NowPlayingScreenContent(
                                         PlayerControlLayout(
                                             controllerState,
                                             isPodcast = isPodcast,
+                                            podcastRewindSeconds = podcastRewindSeconds,
+                                            podcastForwardSeconds = podcastForwardSeconds,
                                         ) {
                                             sharedViewModel.onUIEvent(it)
                                         }

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/player/NowPlayingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/player/NowPlayingScreen.kt
@@ -122,6 +122,7 @@ import coil3.request.crossfade
 import coil3.toBitmap
 import com.kmpalette.rememberPaletteState
 import com.maxrave.common.Config.MAIN_PLAYER
+import com.maxrave.domain.extension.isPodcast
 import com.maxrave.domain.mediaservice.handler.MediaPlayerHandler
 import com.maxrave.domain.mediaservice.handler.RepeatState
 import com.maxrave.logger.Logger
@@ -306,6 +307,7 @@ fun NowPlayingScreenContent(
     // Artwork Pager state — Spotify-style horizontal swipe between queue tracks.
     // The pager wraps the Canvas + Thumbnail layers. Controller layout below stays fixed.
     val nowPlayingState by sharedViewModel.nowPlayingState.collectAsStateWithLifecycle()
+    val isPodcast = nowPlayingState?.track?.isPodcast() == true || nowPlayingState?.songEntity?.isPodcast() == true
     val queueDataState by sharedViewModel.getQueueDataState().collectAsStateWithLifecycle()
     val artworkQueue by remember {
         derivedStateOf { queueDataState?.data?.listTracks ?: emptyList() }
@@ -1578,7 +1580,7 @@ fun NowPlayingScreenContent(
                                                 }
                                             }
                                         }
-                                        if (sharedViewModel.isUserLoggedIn()) {
+                                        if (!isPodcast && sharedViewModel.isUserLoggedIn()) {
                                             Spacer(modifier = Modifier.size(16.dp))
                                             Crossfade(
                                                 targetState = likeStatus,
@@ -1620,9 +1622,11 @@ fun NowPlayingScreenContent(
                                                 }
                                             }
                                         }
-                                        Spacer(modifier = Modifier.size(12.dp))
-                                        HeartCheckBox(checked = controllerState.isLiked, size = 32) {
-                                            sharedViewModel.onUIEvent(UIEvent.ToggleLike)
+                                        if (!isPodcast) {
+                                            Spacer(modifier = Modifier.size(12.dp))
+                                            HeartCheckBox(checked = controllerState.isLiked, size = 32) {
+                                                sharedViewModel.onUIEvent(UIEvent.ToggleLike)
+                                            }
                                         }
                                     }
                                     if (getPlatform() == Platform.Android) {
@@ -1800,6 +1804,7 @@ fun NowPlayingScreenContent(
                                         // Control Button Layout
                                         PlayerControlLayout(
                                             controllerState,
+                                            isPodcast = isPodcast,
                                         ) {
                                             sharedViewModel.onUIEvent(it)
                                         }
@@ -1862,22 +1867,23 @@ fun NowPlayingScreenContent(
                                             horizontalArrangement = Arrangement.spacedBy(12.dp),
                                             verticalAlignment = Alignment.CenterVertically,
                                         ) {
-                                            // NEW: Add to Playlist Button (Center-Right)
-                                            IconButton(
-                                                modifier =
-                                                    Modifier
-                                                        .size(24.dp)
-                                                        .aspectRatio(1f)
-                                                        .clip(CircleShape),
-                                                onClick = {
-                                                    showAddToPlaylistDirectly = true
-                                                },
-                                            ) {
-                                                Icon(
-                                                    imageVector = SimpIcons.PlaylistAdd,
-                                                    tint = Color.White,
-                                                    contentDescription = "Add to Playlist",
-                                                )
+                                            if (!isPodcast) {
+                                                IconButton(
+                                                    modifier =
+                                                        Modifier
+                                                            .size(24.dp)
+                                                            .aspectRatio(1f)
+                                                            .clip(CircleShape),
+                                                    onClick = {
+                                                        showAddToPlaylistDirectly = true
+                                                    },
+                                                ) {
+                                                    Icon(
+                                                        imageVector = SimpIcons.PlaylistAdd,
+                                                        tint = Color.White,
+                                                        contentDescription = "Add to Playlist",
+                                                    )
+                                                }
                                             }
 
                                             // Queue Button (Right)
@@ -2101,7 +2107,7 @@ fun NowPlayingScreenContent(
                                                         }
                                                     }
                                                 }
-                                                if (sharedViewModel.isUserLoggedIn()) {
+                                                if (!isPodcast && sharedViewModel.isUserLoggedIn()) {
                                                     Spacer(modifier = Modifier.size(16.dp))
                                                     Crossfade(
                                                         targetState = likeStatus,
@@ -2147,9 +2153,11 @@ fun NowPlayingScreenContent(
                                                         }
                                                     }
                                                 }
-                                                Spacer(modifier = Modifier.size(12.dp))
-                                                HeartCheckBox(checked = controllerState.isLiked, size = 32) {
-                                                    sharedViewModel.onUIEvent(UIEvent.ToggleLike)
+                                                if (!isPodcast) {
+                                                    Spacer(modifier = Modifier.size(12.dp))
+                                                    HeartCheckBox(checked = controllerState.isLiked, size = 32) {
+                                                        sharedViewModel.onUIEvent(UIEvent.ToggleLike)
+                                                    }
                                                 }
                                             }
                                         }
@@ -2581,8 +2589,10 @@ fun NowPlayingScreenContent(
                             }
                         }
                         Spacer(modifier = Modifier.width(15.dp))
-                        HeartCheckBox(checked = controllerState.isLiked, size = 30) {
-                            sharedViewModel.onUIEvent(UIEvent.ToggleLike)
+                        if (!isPodcast) {
+                            HeartCheckBox(checked = controllerState.isLiked, size = 30) {
+                                sharedViewModel.onUIEvent(UIEvent.ToggleLike)
+                            }
                         }
                         Spacer(modifier = Modifier.width(15.dp))
                         Crossfade(targetState = timelineState.loading, label = "") {

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/NowPlayingBottomSheetViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/NowPlayingBottomSheetViewModel.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.lastOrNull
 import kotlinx.coroutines.flow.singleOrNull
 import kotlinx.coroutines.flow.update
@@ -355,8 +356,13 @@ class NowPlayingBottomSheetViewModel(
                 }
 
                 is NowPlayingBottomSheetUIEvent.ChangePlaybackSpeedPitch -> {
-                    dataStoreManager.setPlaybackSpeed(ev.speed)
-                    dataStoreManager.setPitch(ev.pitch)
+                    if (songUIState.isPodcast) {
+                        dataStoreManager.setPodcastPlaybackSpeed(ev.speed)
+                        dataStoreManager.setPodcastPitch(ev.pitch)
+                    } else if (dataStoreManager.crossfadeEnabled.first() != DataStoreManager.TRUE) {
+                        dataStoreManager.setPlaybackSpeed(ev.speed)
+                        dataStoreManager.setPitch(ev.pitch)
+                    }
                 }
 
                 is NowPlayingBottomSheetUIEvent.Share -> {

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/NowPlayingBottomSheetViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/NowPlayingBottomSheetViewModel.kt
@@ -9,6 +9,7 @@ import com.maxrave.domain.data.model.searchResult.playlists.PlaylistsResult
 import com.maxrave.domain.data.model.searchResult.songs.Album
 import com.maxrave.domain.data.model.searchResult.songs.Artist
 import com.maxrave.domain.data.model.streams.YouTubeWatchEndpoint
+import com.maxrave.domain.extension.isPodcast
 import com.maxrave.domain.manager.DataStoreManager
 import com.maxrave.domain.manager.DataStoreManager.Values.BETTER_LYRICS
 import com.maxrave.domain.manager.DataStoreManager.Values.LRCLIB
@@ -202,6 +203,7 @@ class NowPlayingBottomSheetViewModel(
                                         thumbnails = song.thumbnails,
                                         liked = song.liked,
                                         downloadState = song.downloadState,
+                                        isPodcast = song.isPodcast(),
                                         album =
                                             song.albumName?.takeIf { it.isNotEmpty() }?.let { name ->
                                                 Album(name = name, id = song.albumId ?: "")
@@ -419,6 +421,7 @@ data class NowPlayingBottomSheetUIState(
         val liked: Boolean = false,
         val isAddedToYouTubeLiked: Boolean = false,
         val downloadState: Int = DownloadState.STATE_NOT_DOWNLOADED,
+        val isPodcast: Boolean = false,
         val album: Album? = null,
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/PodcastViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/PodcastViewModel.kt
@@ -25,10 +25,12 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.singleOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -101,29 +103,32 @@ class PodcastViewModel(
 
     init {
         viewModelScope.launch {
-            combine(mediaPlayerHandler.nowPlayingState, mediaPlayerHandler.simpleMediaState) { nowPlaying, mediaState ->
-                nowPlaying to mediaState
-            }.collectLatest { (nowPlaying, mediaState) ->
-                val isPodcast = nowPlaying.track?.isPodcast() == true || nowPlaying.songEntity?.isPodcast() == true
-                if (!isPodcast) return@collectLatest
-                val videoId = nowPlaying.track?.videoId ?: nowPlaying.songEntity?.videoId ?: return@collectLatest
-                when (mediaState) {
-                    is SimpleMediaState.Progress -> {
-                        val progressSecond = mediaState.progress / 1_000L
-                        if (videoId != lastProgressVideoId || progressSecond != lastProgressSecond) {
-                            lastProgressVideoId = videoId
-                            lastProgressSecond = progressSecond
-                            _episodeProgress.update { it + (videoId to mediaState.progress) }
+            mediaPlayerHandler.nowPlayingState
+                .map { nowPlaying ->
+                    val isPodcast = nowPlaying.track?.isPodcast() == true || nowPlaying.songEntity?.isPodcast() == true
+                    if (isPodcast) nowPlaying.track?.videoId ?: nowPlaying.songEntity?.videoId else null
+                }.distinctUntilChanged()
+                .collectLatest { videoId ->
+                    if (videoId == null) return@collectLatest
+                    mediaPlayerHandler.simpleMediaState.collect { mediaState ->
+                        when (mediaState) {
+                            is SimpleMediaState.Progress -> {
+                                val progressSecond = mediaState.progress / 1_000L
+                                if (videoId != lastProgressVideoId || progressSecond != lastProgressSecond) {
+                                    lastProgressVideoId = videoId
+                                    lastProgressSecond = progressSecond
+                                    _episodeProgress.update { it + (videoId to mediaState.progress) }
+                                }
+                            }
+
+                            SimpleMediaState.Ended -> {
+                                _episodeProgress.update { it + (videoId to 0L) }
+                            }
+
+                            else -> Unit
                         }
                     }
-
-                    SimpleMediaState.Ended -> {
-                        _episodeProgress.update { it + (videoId to 0L) }
-                    }
-
-                    else -> Unit
                 }
-            }
         }
     }
 
@@ -132,6 +137,8 @@ class PodcastViewModel(
         _podcastEntity.value = null
         episodeProgressJob?.cancel()
         _episodeProgress.value = emptyMap()
+        lastProgressVideoId = null
+        lastProgressSecond = -1L
     }
 
     fun getPodcastBrowse(id: String) {

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/PodcastViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/PodcastViewModel.kt
@@ -2,26 +2,39 @@ package com.maxrave.simpmusic.viewModel
 
 import androidx.lifecycle.viewModelScope
 import com.maxrave.common.Config
+import com.maxrave.common.PODCAST_PROGRESS_KEY_PREFIX
+import com.maxrave.domain.data.entities.DownloadState
 import com.maxrave.domain.data.entities.EpisodeEntity
 import com.maxrave.domain.data.entities.PodcastsEntity
 import com.maxrave.domain.data.model.podcast.PodcastBrowse
 import com.maxrave.domain.data.model.searchResult.songs.Artist
+import com.maxrave.domain.extension.isPodcast
+import com.maxrave.domain.manager.DataStoreManager
+import com.maxrave.domain.mediaservice.handler.DownloadHandler
 import com.maxrave.domain.mediaservice.handler.PlaylistType
 import com.maxrave.domain.mediaservice.handler.QueueData
+import com.maxrave.domain.mediaservice.handler.SimpleMediaState
 import com.maxrave.domain.repository.PodcastRepository
+import com.maxrave.domain.repository.SongRepository
 import com.maxrave.domain.utils.Resource
+import com.maxrave.domain.utils.toSongEntity
 import com.maxrave.domain.utils.toTrack
 import com.maxrave.simpmusic.expect.shareUrl
 import com.maxrave.simpmusic.viewModel.base.BaseViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.singleOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import simpmusic.composeapp.generated.resources.Res
+import simpmusic.composeapp.generated.resources.downloaded
+import simpmusic.composeapp.generated.resources.downloading
 import simpmusic.composeapp.generated.resources.share_url
 
 // UI state cho podcast
@@ -60,10 +73,15 @@ sealed class PodcastUIEvent {
     data class Share(
         val podcastId: String,
     ) : PodcastUIEvent()
+
+    data object DownloadAll : PodcastUIEvent()
 }
 
 class PodcastViewModel(
     private val podcastRepository: PodcastRepository,
+    private val dataStoreManager: DataStoreManager,
+    private val songRepository: SongRepository,
+    private val downloadHandler: DownloadHandler,
 ) : BaseViewModel() {
     private val _uiState = MutableStateFlow<PodcastUIState>(PodcastUIState.Loading)
     val uiState: StateFlow<PodcastUIState> = _uiState.asStateFlow()
@@ -74,9 +92,46 @@ class PodcastViewModel(
     private val _isFavorite = MutableStateFlow(false)
     val isFavorite: StateFlow<Boolean> = _isFavorite.asStateFlow()
 
+    private val _episodeProgress = MutableStateFlow<Map<String, Long>>(emptyMap())
+    val episodeProgress: StateFlow<Map<String, Long>> = _episodeProgress.asStateFlow()
+
+    private var episodeProgressJob: Job? = null
+    private var lastProgressVideoId: String? = null
+    private var lastProgressSecond = -1L
+
+    init {
+        viewModelScope.launch {
+            combine(mediaPlayerHandler.nowPlayingState, mediaPlayerHandler.simpleMediaState) { nowPlaying, mediaState ->
+                nowPlaying to mediaState
+            }.collectLatest { (nowPlaying, mediaState) ->
+                val isPodcast = nowPlaying.track?.isPodcast() == true || nowPlaying.songEntity?.isPodcast() == true
+                if (!isPodcast) return@collectLatest
+                val videoId = nowPlaying.track?.videoId ?: nowPlaying.songEntity?.videoId ?: return@collectLatest
+                when (mediaState) {
+                    is SimpleMediaState.Progress -> {
+                        val progressSecond = mediaState.progress / 1_000L
+                        if (videoId != lastProgressVideoId || progressSecond != lastProgressSecond) {
+                            lastProgressVideoId = videoId
+                            lastProgressSecond = progressSecond
+                            _episodeProgress.update { it + (videoId to mediaState.progress) }
+                        }
+                    }
+
+                    SimpleMediaState.Ended -> {
+                        _episodeProgress.update { it + (videoId to 0L) }
+                    }
+
+                    else -> Unit
+                }
+            }
+        }
+    }
+
     fun clearPodcastBrowse() {
         _uiState.value = PodcastUIState.Loading
         _podcastEntity.value = null
+        episodeProgressJob?.cancel()
+        _episodeProgress.value = emptyMap()
     }
 
     fun getPodcastBrowse(id: String) {
@@ -98,6 +153,7 @@ class PodcastViewModel(
                                         id,
                                         podcastBrowse,
                                     )
+                                loadEpisodeProgress(podcastBrowse.listEpisode)
 
                                 val podcastEntity = podcastRepository.getPodcast(id).firstOrNull()
                                 if (podcastEntity == null) {
@@ -152,6 +208,7 @@ class PodcastViewModel(
                                             id,
                                             podcastBrowse,
                                         )
+                                    loadEpisodeProgress(podcastBrowse.listEpisode)
                                 } ?: run {
                                     _uiState.value = PodcastUIState.Error(resource.message ?: "Unknown error")
                                 }
@@ -261,6 +318,51 @@ class PodcastViewModel(
         }
     }
 
+    private fun loadEpisodeProgress(episodes: List<PodcastBrowse.EpisodeItem>) {
+        episodeProgressJob?.cancel()
+        episodeProgressJob =
+            viewModelScope.launch {
+                _episodeProgress.value =
+                    episodes.associate { episode ->
+                        val progress =
+                            dataStoreManager
+                                .getString("$PODCAST_PROGRESS_KEY_PREFIX${episode.videoId}")
+                                .first()
+                                ?.toLongOrNull()
+                                ?: 0L
+                        episode.videoId to progress
+                    }
+            }
+    }
+
+    private fun downloadAllEpisodes(podcastData: PodcastBrowse) {
+        viewModelScope.launch {
+            val tracks = podcastData.listEpisode.map { it.toTrack() }
+            tracks.forEach { track ->
+                songRepository.insertSong(track.toSongEntity()).singleOrNull()
+            }
+            val songs =
+                songRepository
+                    .getSongsByListVideoId(tracks.map { it.videoId })
+                    .singleOrNull()
+                    .orEmpty()
+            val pending = songs.filter { it.downloadState != DownloadState.STATE_DOWNLOADED }
+            if (pending.isEmpty()) {
+                makeToast(getString(Res.string.downloaded))
+                return@launch
+            }
+
+            makeToast(getString(Res.string.downloading))
+            pending.forEach { episode ->
+                downloadHandler.downloadTrack(
+                    videoId = episode.videoId,
+                    title = episode.title,
+                    thumbnail = episode.thumbnails.orEmpty(),
+                )
+            }
+        }
+    }
+
     fun onUIEvent(event: PodcastUIEvent) {
         val currentState = _uiState.value
         if (currentState !is PodcastUIState.Success) return
@@ -276,7 +378,7 @@ class PodcastViewModel(
                             firstPlayedTrack = firstEpisode.toTrack(),
                             playlistId = event.podcastId,
                             playlistName = "Podcast \"${podcastData.title}\"",
-                            playlistType = PlaylistType.PLAYLIST,
+                            playlistType = PlaylistType.PODCAST,
                             continuation = null,
                         )
                     setQueueData(queueData)
@@ -302,7 +404,7 @@ class PodcastViewModel(
                             firstPlayedTrack = firstPlayItem.toTrack(),
                             playlistId = event.podcastId,
                             playlistName = "Podcast \"${podcastData.title}\"",
-                            playlistType = PlaylistType.PLAYLIST,
+                            playlistType = PlaylistType.PODCAST,
                             continuation = null,
                         )
                     setQueueData(queueData)
@@ -325,7 +427,7 @@ class PodcastViewModel(
                         firstPlayedTrack = episode.toTrack(),
                         playlistId = event.podcastId,
                         playlistName = "Podcast \"${podcastData.title}\"",
-                        playlistType = PlaylistType.PLAYLIST,
+                        playlistType = PlaylistType.PODCAST,
                         continuation = null,
                     )
                 setQueueData(queueData)
@@ -346,6 +448,10 @@ class PodcastViewModel(
                     title = getString(Res.string.share_url),
                     url = url,
                 )
+            }
+
+            PodcastUIEvent.DownloadAll -> {
+                downloadAllEpisodes(podcastData)
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/SettingsViewModel.kt
@@ -143,6 +143,10 @@ class SettingsViewModel(
     val crossfadeDuration: StateFlow<Int> = _crossfadeDuration
     private val _crossfadeDjMode = MutableStateFlow<Boolean>(true)
     val crossfadeDjMode: StateFlow<Boolean> = _crossfadeDjMode
+    private val _podcastRewindSeconds = MutableStateFlow(DataStoreManager.DEFAULT_PODCAST_SEEK_SECONDS)
+    val podcastRewindSeconds: StateFlow<Int> = _podcastRewindSeconds
+    private val _podcastForwardSeconds = MutableStateFlow(DataStoreManager.DEFAULT_PODCAST_SEEK_SECONDS)
+    val podcastForwardSeconds: StateFlow<Int> = _podcastForwardSeconds
     private val _youtubeSubtitleLanguage = MutableStateFlow<String>("")
     val youtubeSubtitleLanguage: StateFlow<String> = _youtubeSubtitleLanguage
 
@@ -286,6 +290,8 @@ class SettingsViewModel(
         getCrossfadeEnabled()
         getCrossfadeDuration()
         getCrossfadeDjMode()
+        getPodcastRewindSeconds()
+        getPodcastForwardSeconds()
         getContributorNameAndEmail()
         getBackupDownloaded()
         getUpdateChannel()
@@ -472,6 +478,34 @@ class SettingsViewModel(
         viewModelScope.launch {
             dataStoreManager.setCrossfadeDjMode(enabled)
             getCrossfadeDjMode()
+        }
+    }
+
+    private fun getPodcastRewindSeconds() {
+        viewModelScope.launch {
+            dataStoreManager.podcastRewindSeconds.collect { seconds ->
+                _podcastRewindSeconds.value = seconds
+            }
+        }
+    }
+
+    fun setPodcastRewindSeconds(seconds: Int) {
+        viewModelScope.launch {
+            dataStoreManager.setPodcastRewindSeconds(seconds)
+        }
+    }
+
+    private fun getPodcastForwardSeconds() {
+        viewModelScope.launch {
+            dataStoreManager.podcastForwardSeconds.collect { seconds ->
+                _podcastForwardSeconds.value = seconds
+            }
+        }
+    }
+
+    fun setPodcastForwardSeconds(seconds: Int) {
+        viewModelScope.launch {
+            dataStoreManager.setPodcastForwardSeconds(seconds)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/SharedViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/SharedViewModel.kt
@@ -167,6 +167,20 @@ class SharedViewModel(
 
     val castState: StateFlow<GenericCastState> get() = mediaPlayerHandler.castState
 
+    val podcastRewindSeconds =
+        dataStoreManager.podcastRewindSeconds.stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5_000),
+            DataStoreManager.DEFAULT_PODCAST_SEEK_SECONDS,
+        )
+
+    val podcastForwardSeconds =
+        dataStoreManager.podcastForwardSeconds.stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5_000),
+            DataStoreManager.DEFAULT_PODCAST_SEEK_SECONDS,
+        )
+
     private var _controllerState =
         MutableStateFlow<ControlState>(
             ControlState(
@@ -796,6 +810,10 @@ class SharedViewModel(
 
                 UIEvent.Forward -> {
                     mediaPlayerHandler.onPlayerEvent(PlayerEvent.Forward)
+                }
+
+                is UIEvent.SeekBy -> {
+                    mediaPlayerHandler.onPlayerEvent(PlayerEvent.SeekBy(uiEvent.offsetMs))
                 }
 
                 UIEvent.PlayPause -> {
@@ -1952,6 +1970,10 @@ sealed class UIEvent {
     data object Backward : UIEvent()
 
     data object Forward : UIEvent()
+
+    data class SeekBy(
+        val offsetMs: Long,
+    ) : UIEvent()
 
     data object Next : UIEvent()
 


### PR DESCRIPTION
I've improved the podcast player and it makes it easier to control for longer episodes. I use this for my daily and this was just one of the things I felt was missing since I'm a big podcast listener

- Added forward and backward seek buttons for podcasts
- Added settings for 5, 10, 15, 30, or 60 second seek intervals on podcasts
- Added previous and next episode controls
- Podcasts now save playback progress
- Added download options for one episode or all episodes
- Added playback speed controls for podcasts that ignore crossfade settings since podcasts shouldn't crossfade
- Hid music only menu such as adding podcast episodes to playlists in the player menu
- Player and mini player show correct controls as well
- Android notifications, lock screen controls, and the One UI Now Bar now show podcast seek buttons instead of previous and next

Tested using android debug
- S24 Ultra (SM-S928U)
- Android 16
- SDK 36

Tested podcast playback, seeking, playback speed, episode progress, and switching between podcasts and music

Links to: https://github.com/maxrave-dev/core/pull/20
