### PR TITLE
Feat/right click open more content 

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/FullWidthItems.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/FullWidthItems.kt
@@ -171,16 +171,16 @@ fun SongFullWidthItems(
                     .pointerInput(
                         track?.videoId ?: songEntity?.videoId ?: "", onMoreClickListener
                     ) {
-                        awaitEachGesture {
-                            val event = awaitPointerEvent(PointerEventPass.Initial)
-
-                            if (event.type == PointerEventType.Press &&
-                                event.buttons.isSecondaryPressed
-                            ) {
-                                event.changes.forEach { it.consume() }
-                                onMoreClickListener?.invoke(
-                                    track?.videoId ?: songEntity?.videoId ?: ""
-                                )
+                        //Right click opens 'More' modal sheet (designed for desktop but compatible if android has external mouse)
+                        //Ensure right click is consumed before clickable
+                        if (onMoreClickListener != null) {
+                            awaitEachGesture {
+                                val event = awaitPointerEvent(pass = PointerEventPass.Initial)
+                                if (event.type == PointerEventType.Press && event.buttons.isSecondaryPressed
+                                ) {
+                                    event.changes.forEach { it.consume() }
+                                    onMoreClickListener(track?.videoId ?: songEntity?.videoId ?: "")
+                                }
                             }
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/FullWidthItems.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/FullWidthItems.kt
@@ -100,7 +100,10 @@ import simpmusic.composeapp.generated.resources.podcasts
 import simpmusic.composeapp.generated.resources.radio
 import simpmusic.composeapp.generated.resources.you
 import kotlin.math.roundToInt
-
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.isSecondaryPressed
 /**
  * This is the song item in the playlist or other places.
  */
@@ -165,6 +168,22 @@ fun SongFullWidthItems(
             modifier =
                 modifier
                     .offset { IntOffset(offsetX.value.roundToInt(), 0) }
+                    .pointerInput(
+                        track?.videoId ?: songEntity?.videoId ?: "", onMoreClickListener
+                    ) {
+                        awaitEachGesture {
+                            val event = awaitPointerEvent(PointerEventPass.Initial)
+
+                            if (event.type == PointerEventType.Press &&
+                                event.buttons.isSecondaryPressed
+                            ) {
+                                event.changes.forEach { it.consume() }
+                                onMoreClickListener?.invoke(
+                                    track?.videoId ?: songEntity?.videoId ?: ""
+                                )
+                            }
+                        }
+                    }
                     .clickable {
                         onClickListener?.invoke(track?.videoId ?: songEntity?.videoId ?: "")
                     }.animateContentSize()


### PR DESCRIPTION
Hi, I wanted to add a nice Quality of Life change for desktop (and anyone using a mouse on an android device).

Instead of clicking the 'More' button on a song item, you can now right click the item to display the 'More' contents (which is a functionality YT Music and Spotify have). 

The code checks if the mouse button click was a right click (secondary click) instead of a left click (primary click), if it was, call `onMoreClickListener`. If it was a right click, it is consumed so it does not play the song.

Demonstrations: 


https://github.com/user-attachments/assets/91006640-cba5-43f9-aa29-ee19371138ae


https://github.com/user-attachments/assets/60d806a2-b91d-40f0-a4e5-9655ddbc1411

