### PR TITLE
Feat/hold down open more content

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/FullWidthItems.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/FullWidthItems.kt
@@ -100,6 +100,9 @@ import simpmusic.composeapp.generated.resources.podcasts
 import simpmusic.composeapp.generated.resources.radio
 import simpmusic.composeapp.generated.resources.you
 import kotlin.math.roundToInt
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 
 /**
  * This is the song item in the playlist or other places.
@@ -135,6 +138,7 @@ fun SongFullWidthItems(
     }
     val offsetX = remember { Animatable(initialValue = 0f) }
     var heightDp by remember { mutableStateOf(0.dp) }
+    val haptics = LocalHapticFeedback.current
 
     Box(
         modifier =
@@ -165,9 +169,15 @@ fun SongFullWidthItems(
             modifier =
                 modifier
                     .offset { IntOffset(offsetX.value.roundToInt(), 0) }
-                    .clickable {
-                        onClickListener?.invoke(track?.videoId ?: songEntity?.videoId ?: "")
-                    }.animateContentSize()
+                    .combinedClickable(
+                        onClick = {
+                            onClickListener?.invoke(track?.videoId ?: songEntity?.videoId ?: "")
+                        },
+                        onLongClick = {
+                            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                            onMoreClickListener?.invoke(track?.videoId ?: songEntity?.videoId ?: "")
+                        },
+                    ).animateContentSize()
                     .pointerInput(Unit) {
                         if (!isPlaying && onAddToQueue != null) {
                             detectHorizontalDragGestures(

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
@@ -1211,6 +1211,7 @@ private enum class QueueItemAction {
     UP,
     DOWN,
     DELETE,
+    PLAYNEXT,
 }
 
 @Composable
@@ -1236,6 +1237,7 @@ fun QueueItemBottomSheet(
         listOf(
             QueueItemAction.UP,
             QueueItemAction.DOWN,
+            QueueItemAction.PLAYNEXT,
             QueueItemAction.DELETE,
         )
     ModalBottomSheet(
@@ -1293,6 +1295,7 @@ fun QueueItemBottomSheet(
                             when (action) {
                                 QueueItemAction.UP -> !canMoveUp
                                 QueueItemAction.DOWN -> !canMoveDown
+                                QueueItemAction.PLAYNEXT -> false
                                 QueueItemAction.DELETE -> false
                             }
                         if (disable) return@items
@@ -1312,6 +1315,19 @@ fun QueueItemBottomSheet(
                                             QueueItemAction.DOWN -> {
                                                 coroutineScope.launch {
                                                     musicServiceHandler.moveItemDown(index)
+                                                }
+                                            }
+
+                                            QueueItemAction.PLAYNEXT ->{
+                                                val track =
+                                                    musicServiceHandler.queueData.value
+                                                        ?.data
+                                                        ?.listTracks
+                                                        ?.getOrNull(index)
+                                                if (track != null) {
+                                                    coroutineScope.launch {
+                                                        musicServiceHandler.playNext(track)
+                                                    }
                                                 }
                                             }
 
@@ -1349,6 +1365,16 @@ fun QueueItemBottomSheet(
                                         )
                                     }
 
+                                    QueueItemAction.PLAYNEXT -> {
+                                        Image(
+                                            painter =
+                                                painterResource(
+                                                    Res.drawable.play_circle,
+                                                ),
+                                            contentDescription = "Play next"
+                                        )
+                                    }
+
                                     QueueItemAction.DELETE -> {
                                         Image(
                                             painter =
@@ -1366,6 +1392,7 @@ fun QueueItemBottomSheet(
                                             when (action) {
                                                 QueueItemAction.UP -> Res.string.move_up
                                                 QueueItemAction.DOWN -> Res.string.move_down
+                                                QueueItemAction.PLAYNEXT -> Res.string.play_next
                                                 QueueItemAction.DELETE -> Res.string.delete
                                             },
                                         ),


### PR DESCRIPTION
Hi, wanted to add in a nice QoL change that is applicable to both desktop and mobile.

Originally to reach the more content of a song, you'd have to click the icon on the right hand side. To speed this up, I added a QoL change so where if you long click a song, it'll open it up. 

Desktop: 

https://github.com/user-attachments/assets/33943a62-b9bc-4cd3-b560-8616990a6105

Android: 


https://github.com/user-attachments/assets/158bbbff-0bd4-47b3-a8a5-fc49badfed56

