### PR TITLE
Feat/Long click open more

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/FullWidthItems.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/FullWidthItems.kt
@@ -100,6 +100,9 @@ import simpmusic.composeapp.generated.resources.podcasts
 import simpmusic.composeapp.generated.resources.radio
 import simpmusic.composeapp.generated.resources.you
 import kotlin.math.roundToInt
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 
 /**
  * This is the song item in the playlist or other places.
@@ -135,6 +138,7 @@ fun SongFullWidthItems(
     }
     val offsetX = remember { Animatable(initialValue = 0f) }
     var heightDp by remember { mutableStateOf(0.dp) }
+    val haptics = LocalHapticFeedback.current
 
     Box(
         modifier =
@@ -165,9 +169,15 @@ fun SongFullWidthItems(
             modifier =
                 modifier
                     .offset { IntOffset(offsetX.value.roundToInt(), 0) }
-                    .clickable {
-                        onClickListener?.invoke(track?.videoId ?: songEntity?.videoId ?: "")
-                    }.animateContentSize()
+                    .combinedClickable(
+                        onClick = {
+                            onClickListener?.invoke(track?.videoId ?: songEntity?.videoId ?: "")
+                        },
+                        onLongClick = {
+                            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                            onMoreClickListener?.invoke(track?.videoId ?: songEntity?.videoId ?: "")
+                        },
+                    ).animateContentSize()
                     .pointerInput(Unit) {
                         if (!isPlaying && onAddToQueue != null) {
                             detectHorizontalDragGestures(


### PR DESCRIPTION
Hi, wanted to add in a nice QoL change that is applicable to both desktop and mobile.

Originally to reach the more content of a song, you'd have to click the icon on the right hand side. To speed this up, I added a QoL change so where if you long click a song, it'll open it up.

Desktop:


https://github.com/user-attachments/assets/d02fc43e-717a-44fb-8aa1-5deb0a815fcd

Android:


https://github.com/user-attachments/assets/b2fc3776-e5aa-49c9-9c95-8b74cd43fe66

