### PR TITLE
Feat/on left swipe delete from queue

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/FullWidthItems.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/FullWidthItems.kt
@@ -74,6 +74,7 @@ import com.maxrave.domain.repository.SongRepository
 import com.maxrave.domain.utils.connectArtists
 import com.maxrave.domain.utils.toListName
 import com.maxrave.simpmusic.ui.icon.Add
+import com.maxrave.simpmusic.ui.icon.Delete
 import com.maxrave.simpmusic.ui.icon.DownloadForOffline
 import com.maxrave.simpmusic.ui.icon.DragHandle
 import com.maxrave.simpmusic.ui.icon.MoreVert
@@ -95,6 +96,7 @@ import simpmusic.composeapp.generated.resources.Res
 import simpmusic.composeapp.generated.resources.add_to_queue
 import simpmusic.composeapp.generated.resources.album
 import simpmusic.composeapp.generated.resources.artists
+import simpmusic.composeapp.generated.resources.delete_from_queue
 import simpmusic.composeapp.generated.resources.playlist
 import simpmusic.composeapp.generated.resources.podcasts
 import simpmusic.composeapp.generated.resources.radio
@@ -114,6 +116,7 @@ fun SongFullWidthItems(
     onMoreClickListener: ((videoId: String) -> Unit)? = null,
     onClickListener: ((videoId: String) -> Unit)? = null,
     onAddToQueue: ((videoId: String) -> Unit)? = null,
+    onRemoveFromQueue: ((videoId: String) -> Unit)? = null,
     modifier: Modifier,
     rightView: @Composable (() -> Unit)? = null,
     forceDark: Boolean = LocalForceDarkText.current,
@@ -138,25 +141,44 @@ fun SongFullWidthItems(
 
     Box(
         modifier =
-        modifier,
+            modifier,
     ) {
-        Crossfade(
-            offsetX.value >= maxOffset / 2,
-        ) { shouldShowAddToQueue ->
-            if (shouldShowAddToQueue) {
+        // right-swipe indicator (existing, unchanged)
+        Crossfade(offsetX.value >= maxOffset / 2,
+            modifier = Modifier.align(Alignment.CenterStart)) { shouldShow ->
+            if (shouldShow && onAddToQueue != null) {
                 Box(
                     modifier =
                         Modifier
                             .height(heightDp)
                             .aspectRatio(1f)
-                            .padding(start = 15.dp)
-                            .align(Alignment.CenterStart),
+                            .padding(start = 15.dp),
                     contentAlignment = Alignment.Center,
                 ) {
                     Icon(
                         tint = contentColor,
                         imageVector = SimpIcons.QueueMusic,
                         contentDescription = stringResource(Res.string.add_to_queue),
+                    )
+                }
+            }
+        }
+        // left-swipe indicator (NEW)
+        Crossfade(offsetX.value <= -maxOffset / 2,
+            modifier = Modifier.align(Alignment.CenterEnd)) { shouldShow ->
+            if (shouldShow && onRemoveFromQueue != null) {
+                Box(
+                    modifier =
+                        Modifier
+                            .height(heightDp)
+                            .aspectRatio(1f)
+                            .padding(end = 15.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        tint = MaterialTheme.colorScheme.error,
+                        imageVector = SimpIcons.Delete,
+                        contentDescription = stringResource(Res.string.delete_from_queue),
                     )
                 }
             }
@@ -169,34 +191,32 @@ fun SongFullWidthItems(
                         onClickListener?.invoke(track?.videoId ?: songEntity?.videoId ?: "")
                     }.animateContentSize()
                     .pointerInput(Unit) {
-                        if (!isPlaying && onAddToQueue != null) {
+                        if (!isPlaying && (onAddToQueue != null || onRemoveFromQueue != null)) {
                             detectHorizontalDragGestures(
                                 onHorizontalDrag = { change, dragAmount ->
-                                    if (offsetX.value + dragAmount > 0) {
+                                    val newOffset = offsetX.value + dragAmount
+                                    val allowed =
+                                        (newOffset > 0f && onAddToQueue != null) ||
+                                            (newOffset < 0f && onRemoveFromQueue != null)
+                                    if (allowed) {
                                         change.consume()
                                         coroutineScope.launch {
-                                            offsetX.snapTo(
-                                                (offsetX.value + dragAmount).coerceAtMost(maxOffset),
-                                            )
+                                            offsetX.snapTo(newOffset.coerceIn(-maxOffset, maxOffset))
                                         }
                                     }
                                 },
                                 onDragEnd = {
-                                    if (offsetX.value == maxOffset) {
-                                        onAddToQueue(
-                                            track?.videoId ?: songEntity?.videoId ?: "",
-                                        )
+                                    val id = track?.videoId ?: songEntity?.videoId ?: ""
+                                    when (offsetX.value) {
+                                        maxOffset -> onAddToQueue?.invoke(id)
+                                        -maxOffset -> onRemoveFromQueue?.invoke(id)
                                     }
-                                    coroutineScope.launch {
-                                        offsetX.animateTo(0f)
-                                    }
+                                    coroutineScope.launch { offsetX.animateTo(0f) }
                                 },
                             )
                         }
                     }.onGloballyPositioned { coordinates ->
-                        with(density) {
-                            heightDp = coordinates.size.height.toDp()
-                        }
+                        with(density) { heightDp = coordinates.size.height.toDp() }
                     },
         ) {
             Row(
@@ -307,7 +327,7 @@ fun SongFullWidthItems(
                                 (
                                     track?.artists?.toListName()?.connectArtists()
                                         ?: songEntity?.artistName?.connectArtists()
-                                ) ?: "",
+                                    ) ?: "",
                             style = typo().bodySmall,
                             maxLines = 1,
                             color = subtitleColor,

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/FullWidthItems.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/FullWidthItems.kt
@@ -143,7 +143,6 @@ fun SongFullWidthItems(
         modifier =
             modifier,
     ) {
-        // right-swipe indicator (existing, unchanged)
         Crossfade(offsetX.value >= maxOffset / 2,
             modifier = Modifier.align(Alignment.CenterStart)) { shouldShow ->
             if (shouldShow && onAddToQueue != null) {
@@ -163,7 +162,7 @@ fun SongFullWidthItems(
                 }
             }
         }
-        // left-swipe indicator (NEW)
+        // Delete
         Crossfade(offsetX.value <= -maxOffset / 2,
             modifier = Modifier.align(Alignment.CenterEnd)) { shouldShow ->
             if (shouldShow && onRemoveFromQueue != null) {
@@ -211,12 +210,15 @@ fun SongFullWidthItems(
                                         maxOffset -> onAddToQueue?.invoke(id)
                                         -maxOffset -> onRemoveFromQueue?.invoke(id)
                                     }
-                                    coroutineScope.launch { offsetX.animateTo(0f) }
+                                    coroutineScope.launch {
+                                        offsetX.animateTo(0f)
+                                    }
                                 },
                             )
                         }
                     }.onGloballyPositioned { coordinates ->
-                        with(density) { heightDp = coordinates.size.height.toDp() }
+                        with(density) { heightDp = coordinates.size.height.toDp()
+                        }
                     },
         ) {
             Row(

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/FullWidthItems.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/FullWidthItems.kt
@@ -217,7 +217,8 @@ fun SongFullWidthItems(
                             )
                         }
                     }.onGloballyPositioned { coordinates ->
-                        with(density) { heightDp = coordinates.size.height.toDp()
+                        with(density) {
+                            heightDp = coordinates.size.height.toDp()
                         }
                     },
         ) {

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
@@ -203,6 +203,7 @@ import simpmusic.composeapp.generated.resources.cancel
 import simpmusic.composeapp.generated.resources.codec
 import simpmusic.composeapp.generated.resources.copied_to_clipboard
 import simpmusic.composeapp.generated.resources.delete
+import simpmusic.composeapp.generated.resources.delete_from_queue
 import simpmusic.composeapp.generated.resources.delete_playlist
 import simpmusic.composeapp.generated.resources.delete_song_from_playlist
 import simpmusic.composeapp.generated.resources.description
@@ -903,6 +904,7 @@ fun QueueBottomSheet(
     sharedViewModel: SharedViewModel = koinInject(),
     musicServiceHandler: MediaPlayerHandler = koinInject<MediaPlayerHandler>(),
     dataStoreManager: DataStoreManager = koinInject(),
+    viewModel: NowPlayingBottomSheetViewModel = koinViewModel(),
 ) {
     val coroutineScope = rememberCoroutineScope()
     val localDensity = LocalDensity.current
@@ -1078,6 +1080,7 @@ fun QueueBottomSheet(
                     songEntity = songEntity,
                     isPlaying = false,
                     onAddToQueue = null,
+                    onRemoveFromQueue = null,
                     modifier =
                         Modifier
                             .fillMaxWidth()
@@ -1185,6 +1188,12 @@ fun QueueBottomSheet(
                                         sharedViewModel.addListToQueue(
                                             arrayListOf(track),
                                         )
+                                    },
+                                    onRemoveFromQueue = {
+                                        coroutineScope.launch {
+                                            musicServiceHandler.removeMediaItem(index)
+                                            viewModel.makeToast(getString(Res.string.delete_from_queue))
+                                        }
                                     },
                                 )
                             }

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
@@ -904,7 +904,6 @@ fun QueueBottomSheet(
     sharedViewModel: SharedViewModel = koinInject(),
     musicServiceHandler: MediaPlayerHandler = koinInject<MediaPlayerHandler>(),
     dataStoreManager: DataStoreManager = koinInject(),
-    viewModel: NowPlayingBottomSheetViewModel = koinViewModel(),
 ) {
     val coroutineScope = rememberCoroutineScope()
     val localDensity = LocalDensity.current
@@ -1192,7 +1191,7 @@ fun QueueBottomSheet(
                                     onRemoveFromQueue = {
                                         coroutineScope.launch {
                                             musicServiceHandler.removeMediaItem(index)
-                                            viewModel.makeToast(getString(Res.string.delete_from_queue))
+                                            sharedViewModel.makeToast(getString(Res.string.delete_from_queue))
                                         }
                                     },
                                 )


### PR DESCRIPTION
Hi, I saw people mention wanting to be able to swipe to the left to delete a song from the queue, so I added it using the same style as swiping to the right to add a song to the queue. 

Note 1: The videos display the add to queue button functionality still working. 
Note 2: I moved `modifier = Modifier.align(Alignment.CenterStart)` inside to crossfade because when I tried following the original pattern, but instead with Alignment.CenterEnd, to place the delete icon on the righthand side, it would stay on the left. Moving it solved this error. Everything else is in the same pattern as the original swipe logic.
Note 3: Delete button is red but could be changed to same color scheme as the queue button for consistency. 

Android:

https://github.com/user-attachments/assets/8f5851ff-ae1d-4a7d-ad4c-08db6ee4dbf2

Desktop:

https://github.com/user-attachments/assets/0790d080-d037-4b83-a7ac-ddaacbd18775

Illustrating Alignment.CenterEnd when placed within the Box and not Crossfade: 
<img width="642" height="652" alt="image" src="https://github.com/user-attachments/assets/55874de5-7333-4547-887d-b68efc00a1d6" />



