### PR TITLE
feat: add issue templates for playback errors and desktop issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,6 +18,15 @@ body:
         - label: I confirm I searched for existing reports and found no duplicates.
           required: true
 
+  - type: checkboxes
+    id: latest_release
+    attributes:
+      label: Latest Release
+      description: Check the [Releases page](https://github.com/maxrave-dev/SimpMusic/releases) — this may already be fixed.
+      options:
+        - label: I confirm I am on the latest release and the problem still happens.
+          required: true
+
   - type: textarea
     id: bug_description
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord Community
+    url: https://discord.gg/Rq5tWVM9Hg
+    about: Ask questions, get help, and chat with other users before opening an issue
+  - name: FAQ
+    url: https://github.com/maxrave-dev/SimpMusic#faq
+    about: Check the FAQ — common questions (lyrics accuracy, the app name, and more) are answered here

--- a/.github/ISSUE_TEMPLATE/desktop_issue.yml
+++ b/.github/ISSUE_TEMPLATE/desktop_issue.yml
@@ -1,0 +1,96 @@
+name: Desktop app issue
+description: Report a problem specific to the Windows, macOS, or Linux desktop app
+labels: [ "bug:unconfirmed", "desktop" ]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ⚠️ **Important:**
+        Issues that are incomplete or not properly filled out will be closed without further explanation.
+
+  - type: checkboxes
+    id: duplicate_check
+    attributes:
+      label: Duplicate Check
+      description: Confirm you searched both open and closed issues.
+      options:
+        - label: I confirm I searched for existing reports and found no duplicates.
+          required: true
+
+  - type: checkboxes
+    id: latest_release
+    attributes:
+      label: Latest Release
+      description: Check the [Releases page](https://github.com/maxrave-dev/SimpMusic/releases) — this may already be fixed.
+      options:
+        - label: I confirm I am on the latest release and the problem still happens.
+          required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - Windows
+        - macOS
+        - Linux
+    validations:
+      required: true
+
+  - type: input
+    id: package_format
+    attributes:
+      label: Package Downloaded
+      description: "As described in the README's Desktop app section."
+      placeholder: e.g. .msix installer (Windows), .dmg (macOS), .AppImage (Linux)
+    validations:
+      required: true
+
+  - type: input
+    id: desktop_environment
+    attributes:
+      label: Desktop Environment (Linux only)
+      description: e.g. GNOME/X11, KDE/Wayland, Hyprland. Leave blank on Windows/macOS.
+      placeholder: e.g. Hyprland (Wayland)
+
+  - type: input
+    id: version
+    attributes:
+      label: App Version
+      placeholder: e.g. 1.7.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: bug_description
+    attributes:
+      label: Describe the Bug
+      placeholder: Briefly describe the bug you encountered.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1. …
+        2. …
+        3. …
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      placeholder: Describe what you expected to happen instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Log / Error Details
+      placeholder: Paste any error message, crash dialog text, or terminal output.

--- a/.github/ISSUE_TEMPLATE/playback_error.yml
+++ b/.github/ISSUE_TEMPLATE/playback_error.yml
@@ -1,0 +1,108 @@
+name: Playback error
+description: Music stops, fails to start, or errors out during playback
+labels: [ "bug:unconfirmed", "playback" ]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ⚠️ **Important:**
+        Issues that are incomplete or not properly filled out will be closed without further explanation.
+
+  - type: checkboxes
+    id: duplicate_check
+    attributes:
+      label: Duplicate Check
+      description: Confirm you searched both open and closed issues.
+      options:
+        - label: I confirm I searched for existing reports and found no duplicates.
+          required: true
+
+  - type: checkboxes
+    id: latest_release
+    attributes:
+      label: Latest Release
+      description: Check the [Releases page](https://github.com/maxrave-dev/SimpMusic/releases) — this may already be fixed.
+      options:
+        - label: I confirm I am on the latest release and the problem still happens.
+          required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Android
+        - Desktop (Windows)
+        - Desktop (macOS)
+        - Desktop (Linux)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: build_variant
+    attributes:
+      label: Build Variant
+      options:
+        - Full
+        - FOSS
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: App Version
+      placeholder: e.g. 1.7.0
+    validations:
+      required: true
+
+  - type: input
+    id: previous_version
+    attributes:
+      label: Did this work in a previous version?
+      placeholder: e.g. "Yes, worked fine on 1.5.1" or "No, never worked"
+
+  - type: checkboxes
+    id: context
+    attributes:
+      label: Context
+      description: Check any that apply — helps narrow down the cause.
+      options:
+        - label: I am logged in to a YouTube Music account
+        - label: Crossfade or DJ-style transition is enabled
+        - label: The problem started right after a network interruption (Wi-Fi drop, mobile signal loss, etc.)
+
+  - type: textarea
+    id: bug_description
+    attributes:
+      label: Describe the Bug
+      placeholder: What happens — does playback stop, fail to start, skip, show an error message?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1. …
+        2. …
+        3. …
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      placeholder: Describe what you expected to happen instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Log / Error Details
+      placeholder: Paste any error message or crash log shown.


### PR DESCRIPTION
Adds a `config.yml` (disables blank issues, adds contact links to Discord
and the FAQ) and two new issue forms:

- **`playback_error.yml`** — platform/build-variant/login/crossfade
  context fields the generic bug report doesn't ask for. Aimed at the
  recurring "playback stops after a network blip" pattern (e.g. #2239,
  #2301).
- **`desktop_issue.yml`** — OS, package format, and (Linux-only) desktop
  environment fields. `bug_report.yml` is Android-oriented (asks for
  Android version, device model, custom ROM) with nowhere for desktop
  users to report OS/DE. Aimed at issues like #1692 (Wayland).

Also adds a "confirm latest release installed" checkbox to
`bug_report.yml`, alongside the existing duplicate-check one — several
recent reports turned out to already be fixed in a later release.

No functional/app code touched, template-only.