### PR TITLE
fix(desktop): stop bundling glib in the Linux libmpv slice

### DIFF
--- a/scripts/mpv-linux/stage.sh
+++ b/scripts/mpv-linux/stage.sh
@@ -21,7 +21,7 @@ ldconfig
 SYSTEM_LIBS="
 libc.so.6 libm.so.6 libdl.so.2 libpthread.so.0 librt.so.1 libutil.so.1
 ld-linux-x86-64.so.2 libgcc_s.so.1 libstdc++.so.6 libresolv.so.2
-libz.so.1 libbz2.so.1.0 liblzma.so.5
+libz.so.1 libbz2.so.1.0 liblzma.so.5 libglib-2.0.so.0
 "
 
 is_system() {


### PR DESCRIPTION
## What

`scripts/mpv-linux/stage.sh` bundles `libglib-2.0.so.0` (2.72, from the Ubuntu 22.04 stage container) into the Linux libmpv slice because it wasn't in `SYSTEM_LIBS`. On a newer glib host (e.g. Ubuntu 24.04, glib 2.80), the bundled glib claims the soname before AWT's `XDesktopPeer.init()` can `dlopen` the system `libgio-2.0.so.0`, which then fails with an undefined symbol and disables `java.awt.Desktop` for the rest of the process — breaking all 23 external-link call sites via `LocalUriHandler`.

This is the root cause already documented in `CLAUDE.md`'s 2026-07-31 entry ("Bundled glib disabled `java.awt.Desktop` on Linux"), which also names the cure directly: *"The actual cure is to stop bundling glib — add it to `SYSTEM_LIBS`, which needs the Linux tarball rebuilt, republished and re-pinned in `mpvNativesChecksums`."* This PR is that first half.

Adding `libglib-2.0.so.0` to `SYSTEM_LIBS` excludes it from the bundle, so the loader falls through to the host's own glib — same mechanism as every other libc-family exclusion already in that list.

## What this does NOT do

- Doesn't touch the `Desktop.isDesktopSupported()` workaround in `DesktopApp.kt` — still needed for anyone on the currently-published tarball, and removing it here would break them.
- Doesn't rebuild/republish the actual tarball or re-pin `mpvNativesChecksums` — per `CLAUDE.md`, that only happens through `mpvBundleAll`, which I don't have access to.

## Verification

I don't have the `mpvBundleAll` pipeline available, so this hasn't been tested against a real staged build. `bash -n` and `shellcheck` both clean on the modified script — no new warnings introduced. Happy to help however's useful once it's staged on your end (e.g. confirming the fix against a built artifact, if you can share one).

## AI disclosure

This PR was drafted with Claude Code's help — it traced the fix against your own `CLAUDE.md` root-cause entry, and I reviewed and confirmed the change before opening this.