### PR TITLE
refactor(app): reduce background GPU/CPU overhead, add in-memory image cache, and smooth out UI lists

### DIFF
--- a/androidApp/src/main/java/com/maxrave/simpmusic/SimpMusicApplication.kt
+++ b/androidApp/src/main/java/com/maxrave/simpmusic/SimpMusicApplication.kt
@@ -12,6 +12,7 @@ import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.SingletonImageLoader
 import coil3.disk.DiskCache
+import coil3.memory.MemoryCache
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.CachePolicy
 import coil3.request.crossfade
@@ -90,7 +91,7 @@ class SimpMusicApplication :
         @SuppressLint("DiscouragedPrivateApi")
         val field: Field = CursorWindow::class.java.getDeclaredField("sCursorWindowSize")
         field.isAccessible = true
-        val expectSize = 100 * 1024 * 1024
+        val expectSize = 32 * 1024 * 1024
         field.set(null, expectSize)
 
         AppContext.apply {
@@ -115,6 +116,11 @@ class SimpMusicApplication :
                         },
                     ),
                 )
+            }.memoryCache {
+                MemoryCache.Builder()
+                    .maxSizePercent(context, 0.20)
+                    .strongReferencesEnabled(true)
+                    .build()
             }.diskCachePolicy(CachePolicy.ENABLED)
             .networkCachePolicy(CachePolicy.ENABLED)
             .diskCache(

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/AnimationComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/AnimationComponents.kt
@@ -53,6 +53,22 @@ fun InfiniteBorderAnimationView(
     oneCircleDurationMillis: Int = 3000,
     content: @Composable () -> Unit,
 ) {
+    if (!isAnimated) {
+        Surface(
+            modifier = Modifier.padding(borderWidth),
+            color = backgroundColor,
+            shape = shape,
+        ) {
+            Box(
+                modifier = Modifier.background(backgroundColor).padding(contentPadding),
+                contentAlignment = Alignment.Center,
+            ) {
+                content()
+            }
+        }
+        return
+    }
+
     val infiniteTransition = rememberInfiniteTransition(label = "Infinite Color Animation")
     val degrees by infiniteTransition.animateFloat(
         initialValue = 90f,
@@ -65,7 +81,7 @@ fun InfiniteBorderAnimationView(
         label = "Infinite Colors",
     )
     val scaleAnimationValue by animateFloatAsState(
-        if (isAnimated) 1f else 0f,
+        1f,
         tween(800),
     )
     Surface(
@@ -94,7 +110,7 @@ fun InfiniteBorderAnimationView(
             modifier =
                 Modifier
                     .background(
-                        color = if (isAnimated) Color.Black else backgroundColor,
+                        color = Color.Black,
                     ).padding(
                         contentPadding,
                     ),

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/AppleMusicLyricsLines.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/AppleMusicLyricsLines.kt
@@ -182,7 +182,9 @@ fun Modifier.appleMusicLyricFocus(
         if (!blurEnabled || !hasActiveLine || distanceFromCurrent == 0) {
             0.dp
         } else {
-            fontSizeDp * (distance * BLUR_PER_LINE_EM).coerceAtMost(BLUR_MAX_EM)
+            // Cap at 3 lines out to avoid redundant blur shaders for offscreen/far items
+            val clampedDist = distance.coerceAtMost(3)
+            fontSizeDp * (clampedDist * BLUR_PER_LINE_EM).coerceAtMost(BLUR_MAX_EM)
         }
     val targetAlpha =
         when {

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/LyricsView.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/LyricsView.kt
@@ -434,7 +434,10 @@ fun LyricsView(
             modifier = Modifier.fillMaxSize(),
             contentPadding = PaddingValues(top = if (appleStyle) 8.dp else 0.dp, bottom = tailPadding),
         ) {
-            items(lyricsData.lyrics.lines?.size ?: 0) { index ->
+            items(
+                count = lyricsData.lyrics.lines?.size ?: 0,
+                key = { index -> lyricsData.lyrics.lines?.getOrNull(index)?.startTimeMs ?: index },
+            ) { index ->
                 val line = lyricsData.lyrics.lines?.getOrNull(index)
                 // Translated lyrics: synced -> precomputed map by line index, unsynced -> by index.
                 val translatedWords =

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/LyricsView.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/LyricsView.kt
@@ -432,7 +432,7 @@ fun LyricsView(
         LazyColumn(
             state = listState,
             modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(bottom = tailPadding),
+            contentPadding = PaddingValues(top = if (appleStyle) 8.dp else 0.dp, bottom = tailPadding),
         ) {
             items(lyricsData.lyrics.lines?.size ?: 0) { index ->
                 val line = lyricsData.lyrics.lines?.getOrNull(index)

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
@@ -2612,7 +2612,10 @@ fun AddToPlaylistModalBottomSheet(
                         Crossfade(isYouTubePlaylistClicked) { clicked ->
                             if (clicked) {
                                 LazyColumn {
-                                    items(listYouTubePlaylist) { playlist ->
+                                    items(
+                                        items = listYouTubePlaylist,
+                                        key = { it.browseId },
+                                    ) { playlist ->
                                         Box(
                                             modifier =
                                                 Modifier
@@ -2644,7 +2647,10 @@ fun AddToPlaylistModalBottomSheet(
                                 }
                             } else {
                                 LazyColumn {
-                                    items(listLocalPlaylist) { playlist ->
+                                    items(
+                                        items = listLocalPlaylist,
+                                        key = { it.id },
+                                    ) { playlist ->
                                         Box(
                                             modifier =
                                                 Modifier
@@ -2747,7 +2753,10 @@ fun ArtistModalBottomSheet(
                     ) {}
                     Spacer(modifier = Modifier.height(5.dp))
                     LazyColumn {
-                        items(artists) { artist ->
+                        items(
+                            items = artists,
+                            key = { it.id ?: it.name },
+                        ) { artist ->
                             Box(
                                 modifier =
                                     Modifier

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/other/ArtistScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/other/ArtistScreen.kt
@@ -816,7 +816,10 @@ private fun ArtistSections(
                     item {
                         Spacer(Modifier.size(10.dp))
                     }
-                    items(state.data.singles?.results ?: emptyList()) { single ->
+                    items(
+                        items = state.data.singles?.results ?: emptyList(),
+                        key = { it.browseId ?: it.hashCode() },
+                    ) { single ->
                         HomeItemContentPlaylist(
                             forceDark = true,                            onClick = {
                                 navController.navigate(
@@ -884,7 +887,10 @@ private fun ArtistSections(
                     item {
                         Spacer(Modifier.size(10.dp))
                     }
-                    items(state.data.albums?.results ?: emptyList()) { album ->
+                    items(
+                        items = state.data.albums?.results ?: emptyList(),
+                        key = { it.browseId ?: it.hashCode() },
+                    ) { album ->
                         HomeItemContentPlaylist(
                             forceDark = true,                            onClick = {
                                 navController.navigate(
@@ -951,7 +957,10 @@ private fun ArtistSections(
                     item {
                         Spacer(Modifier.size(10.dp))
                     }
-                    items(state.data.video?.video ?: emptyList()) { video ->
+                    items(
+                        items = state.data.video?.video ?: emptyList(),
+                        key = { it.videoId ?: it.hashCode() },
+                    ) { video ->
                         HomeItemVideo(
                             forceDark = true,                            onClick = {
                                 val firstQueue: Track = video

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/other/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/other/SearchScreen.kt
@@ -372,7 +372,10 @@ fun SearchScreen(
                         state = suggestionsState,
                         contentPadding = PaddingValues(top = searchBarHeight, bottom = 10.dp),
                     ) {
-                        items(searchScreenState.suggestYTItems) { item ->
+                        items(
+                            items = searchScreenState.suggestYTItems,
+                            key = { it.hashCode() },
+                        ) { item ->
                             SuggestItemRow(
                                 searchResult = item,
                                 onItemClick = { item ->
@@ -415,7 +418,10 @@ fun SearchScreen(
                                 },
                             )
                         }
-                        items(searchScreenState.suggestQueries) { suggestion ->
+                        items(
+                            items = searchScreenState.suggestQueries,
+                            key = { it },
+                        ) { suggestion ->
                             Row(
                                 modifier =
                                     Modifier
@@ -505,7 +511,10 @@ fun SearchScreen(
                                     }
                                 }
                             }
-                            items(searchHistory) { historyItem ->
+                            items(
+                                items = searchHistory,
+                                key = { it },
+                            ) { historyItem ->
                                 Row(
                                     modifier =
                                         Modifier

--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/player/content/NowPlayingContentAppleMusic.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/screen/player/content/NowPlayingContentAppleMusic.kt
@@ -992,7 +992,7 @@ private fun AppleMusicArtworkPage(
 // Radius of the frosted cover art behind the page. Large enough that no detail of the artwork
 // survives as a shape — what is left is its colour and its broad light and dark areas, which is
 // precisely what Apple's background is.
-private val BACKDROP_BLUR_RADIUS = 80.dp
+private val BACKDROP_BLUR_RADIUS = 60.dp
 
 // How much of the artwork-derived gradient sits over the frosted art. Enough to darken the page
 // towards the bottom so the transport stays readable; not so much that it hides the art again.


### PR DESCRIPTION
## What & why
Addresses multiple UI lag, overheating, and memory overhead issues reported on Android:

* Idle chip GPU waste (AnimationComponents.kt)
* Reduce blur backdrop on Apple design and fix top padding (#2424)
* Add in-memory image cache to avoid constant disk decodes and high CPU usage
* Reduced SQLite CursorWindow size from 100 mb to 32 mb. There are low end device users
* Add missing lazy list item keys across search, artist, and bottom sheets

## Linked issue

Closes #2424

## Checklist

- [x] This PR addresses an accepted issue (linked above)
- [x] I wrote or personally reviewed every line of this change
- [x] I tested it on Android and/or Desktop (say which, and how)