### PR TITLE
fix(ui): prevent out of bounds error in playback speed display (#2418)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/ui/component/ModalBottomSheet.kt
@@ -2145,7 +2145,7 @@ fun PlaybackSpeedPitchBottomSheet(
                         )
                     }
                     Text(
-                        text = "x${String.format("%.1f", playbackSpeed)}",
+                        text = "x${(kotlin.math.round(playbackSpeed * 10f) / 10f)}",
                         style = typo().titleMedium,
                         color = rememberSurfaceDarkColors().subtitle,
                         modifier = Modifier.widthIn(min = 60.dp),


### PR DESCRIPTION
## What & why

* Unsafe Playlist Parsing: The code assumes that the playlist header's subtitle.runs list will always contain at least three items and directly accesses runs.get(2). However, YouTube Music doesn't always return the same response structure.
* Locale-Dependent Formatting: Using platform-dependent formatting such as String.format("%.1f", ...) in multiplatform UI code can also lead to inconsistent behavior across different locales. Since decimal separators and formatting rules vary by system locale, a more platform-independent formatting approach should be used.

## Linked issue

Closes #2418 


## Checklist

- [x] This PR addresses an accepted issue (linked above)
- [x] I wrote or personally reviewed every line of this change
- [ ] I tested it on Android and/or Desktop (say which, and how)
