### PR TITLE
fix(playlist): move instead of swap when reordering local playlist

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/LocalPlaylistViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maxrave/simpmusic/viewModel/LocalPlaylistViewModel.kt
@@ -1041,22 +1041,23 @@ class LocalPlaylistViewModel(
                 )
         } else {
             // Unsynced playlist: local only, no loading dialog needed
-            val loadedList =
-                lazyTrackPagingItems.value?.itemSnapshotList?.toList() ?: return
-            val fromItem = loadedList.getOrNull(from)?.first ?: return
-            val toItem = loadedList.getOrNull(to)?.first ?: return
-            val fromPosition = loadedList.getOrNull(from)?.second?.position ?: from
-            val toPosition = loadedList.getOrNull(to)?.second?.position ?: to
-            val playlistId = uiState.value.id
-
             localPlaylistRepository
-                .changePositionOfSongInPlaylist(playlistId, fromItem.videoId, toPosition)
-                .lastOrNull()
-                ?.let { log("changeLocalPlaylistItemPosition: from $it") }
-            localPlaylistRepository
-                .changePositionOfSongInPlaylist(playlistId, toItem.videoId, fromPosition)
-                .lastOrNull()
-                ?.let { log("changeLocalPlaylistItemPosition: to $it") }
+                .moveItemInLocalPlaylist(
+                    playlistId = uiState.value.id,
+                    fromIndex = from,
+                    toIndex = to,
+                ).collectResource(
+                    onLoading = {
+                        log("changeLocalPlaylistItemPosition (local): loading")
+                    },
+                    onSuccess = {
+                        log("changeLocalPlaylistItemPosition (local): success $it")
+                    },
+                    onError = { message ->
+                        log("changeLocalPlaylistItemPosition (local): error $message")
+                        makeToast(message)
+                    },
+                )
         }
     }
 }


### PR DESCRIPTION
## What & why

Reordering a song in an unsynced local playlist swapped the dragged song with the
song at the target index instead of moving it. Songs in between were never touched,
so an unrelated song was displaced on every drag.

Playlist `A B C D E F`, drag `B` onto `E`:

| | Result |
|---|---|
| Expected | `A C D E B F` |
| Before | `A E C D B F` |

`E` jumped backwards into `B`'s old slot despite never being touched. On a large
playlist, every reorder scrambled a second song elsewhere in the list.

The unsynced branch of `changeLocalPlaylistItemPosition` issued two
`changePositionOfSongInPlaylist` calls, one per song — a swap, with no shift for the
range between them. Synced playlists were unaffected, since `moveItemInSyncedPlaylist`
already does the correct position bookkeeping; reorder behaviour therefore differed
depending on whether the playlist was synced to YouTube.

This points the unsynced branch at a new `moveItemInLocalPlaylist`
(maxrave-dev/core#32), which shifts the affected range and places the moved item at
the target position. Local and synced playlists now share the same semantics.

Handling it in the ViewModel as a loop of `changePositionOfSongInPlaylist` calls was
considered and rejected — that method has a hardcoded `delay(100)`, so it would cost
~100ms per shifted row.

**Depends on maxrave-dev/core#32.** CI here will fail until that merges, since `dev`
still pins the previous core commit. The submodule pointer is deliberately not
committed.

Not yet run on device — verified by compilation only (`:composeApp:compileKotlinJvm`).

## Linked issue

Closes #2326

## Checklist

- [x] This PR addresses an accepted issue (linked above)
- [x] I wrote or personally reviewed every line of this change
- [ ] I tested it on Android and/or Desktop (say which, and how)
